### PR TITLE
WIP spells processed into JSON

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,6 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+.DS_Store
+.vscode

--- a/process-spells-from-export.py
+++ b/process-spells-from-export.py
@@ -1,9 +1,19 @@
 import os
 import re
+from typing import TypedDict
+
 from bs4 import BeautifulSoup
 
-
 normalizationRegex = re.compile('[^a-z\-]')
+
+rel_path_to_parts_folder = os.path.join(
+    "exported-from-adobe", "SRD5.1-CCBY4.0_License_live links_files")
+abs_path_to_parts_folder = os.path.join(os.path.dirname(
+    os.path.abspath(__file__)), rel_path_to_parts_folder)
+
+file_name_for_spell_descriptions = "part646.htm"
+path_for_spell_descriptions = os.path.join(
+    abs_path_to_parts_folder, file_name_for_spell_descriptions)
 
 
 def normalizeString(string: str):
@@ -27,11 +37,45 @@ class SpellLink:
         return f"({self.name}, {self.id}, {self.href}, {self.subLink})"
 
 
-rel_path_to_parts_folder = os.path.join(
-    "exported-from-adobe", "SRD5.1-CCBY4.0_License_live links_files")
-file_name_for_spell_descriptions = "part646.htm"
-path_for_spell_descriptions = os.path.join(
-    os.path.dirname(os.path.abspath(__file__)), rel_path_to_parts_folder, file_name_for_spell_descriptions)
+class SpellInfo(TypedDict):
+    name: str
+    level: int
+    school: str
+
+
+def getSpellInfo(link: SpellLink) -> SpellInfo:
+    output: SpellInfo = {}
+    output["name"] = link.name
+
+    # soup1 always contains the level, school, casting time, and range
+    path_to_part1 = os.path.join(abs_path_to_parts_folder, link.href)
+    with open(path_to_part1) as fp:
+        soup1 = BeautifulSoup(fp, 'lxml')
+    # print(soup1.prettify())
+
+    subheading_tag = soup1.select_one('.s12')
+    if subheading_tag == None:
+        raise RuntimeError(
+            f"Unable to find subheading_tag for spell {link}")
+    subheading = subheading_tag.string.strip()
+    subheading_arr = subheading.split(" ")
+    if subheading[0].isdigit():
+        output["level"] = int(subheading[0])
+        output["school"] = subheading_arr[-1].capitalize()
+    else:
+        output["level"] = 0
+        output["school"] = subheading_arr[0]
+
+    # soup2 contains the rest, starting with components
+    path_to_part2 = path_to_part1
+    if link.subLink != None:
+        path_to_part2 = os.path.join(abs_path_to_parts_folder, link.subLink)
+    with open(path_to_part2) as fp:
+        soup2 = BeautifulSoup(fp, 'lxml')
+    # print(soup2.prettify())
+
+    return output
+
 
 with open(path_for_spell_descriptions) as fp:
     soup = BeautifulSoup(fp, 'lxml')
@@ -47,4 +91,5 @@ for link in soup.find_all('a'):
     else:
         continue
 
-print(srd_spell_links)
+print(getSpellInfo(srd_spell_links[0]))
+print(getSpellInfo(srd_spell_links[1]))

--- a/process-spells-from-export.py
+++ b/process-spells-from-export.py
@@ -77,19 +77,24 @@ def getSpellInfo(link: SpellLink) -> SpellInfo:
     return output
 
 
-with open(path_for_spell_descriptions) as fp:
-    soup = BeautifulSoup(fp, 'lxml')
+def main():
+    with open(path_for_spell_descriptions) as fp:
+        soup = BeautifulSoup(fp, 'lxml')
 
-srd_spell_links: list[SpellLink] = []
-for link in soup.find_all('a'):
-    if link.get('class') == None:
-        continue
-    elif link.get('class') == ['toc0']:
-        srd_spell_links.append(SpellLink(link))
-    elif link.get('class') == ['toc1']:
-        srd_spell_links[-1].addSubLink(link)
-    else:
-        continue
+    srd_spell_links: list[SpellLink] = []
+    for link in soup.find_all('a'):
+        if link.get('class') == None:
+            continue
+        elif link.get('class') == ['toc0']:
+            srd_spell_links.append(SpellLink(link))
+        elif link.get('class') == ['toc1']:
+            srd_spell_links[-1].addSubLink(link)
+        else:
+            continue
 
-print(getSpellInfo(srd_spell_links[0]))
-print(getSpellInfo(srd_spell_links[1]))
+    print(getSpellInfo(srd_spell_links[0]))
+    print(getSpellInfo(srd_spell_links[1]))
+
+
+if __name__ == "__main__":
+    main()

--- a/process-spells-from-export.py
+++ b/process-spells-from-export.py
@@ -116,6 +116,8 @@ def main():
 
     saveSpells(srd_spell_links)
 
+    print("Spell processing complete!")
+
 
 if __name__ == "__main__":
     main()

--- a/process-spells-from-export.py
+++ b/process-spells-from-export.py
@@ -11,6 +11,9 @@ normalizationRegexEmpty = re.compile('[^a-z\-]')
 newlineRegex = re.compile('[\\n]')
 multispaceRegex = re.compile(' {2,}')
 
+allDashRegex = re.compile(r'[\u00ad\u2010\u2011]')
+multiDashRegex = re.compile(r'\-{2,}')
+
 abs_path_to_repo = os.path.dirname(os.path.abspath(__file__))
 
 rel_path_to_parts_folder = os.path.join(
@@ -52,6 +55,7 @@ class SpellInfo(TypedDict):
     school: str
     castingTime: str
     ritual: bool
+    range: str
 
 
 def getSpellInfo(link: SpellLink) -> SpellInfo:
@@ -90,8 +94,13 @@ def getSpellInfo(link: SpellLink) -> SpellInfo:
     casting_time = multispaceRegex.sub(' ', casting_time)
     output["castingTime"] = casting_time.strip()
 
-    # ritual bool should come after casting time
+    # ritual bool should come right after casting time
     output["ritual"] = is_ritual
+
+    spell_range = strings1[spell_range_index + 1]
+    spell_range = allDashRegex.sub('-', spell_range)
+    spell_range = multiDashRegex.sub('-', spell_range)
+    output["range"] = spell_range
 
     # soup2 contains the rest, starting with components
     path_to_part2 = path_to_part1
@@ -133,6 +142,7 @@ def main():
     if DEBUG_SPELL_PROCESSING:
         print(getSpellInfo(srd_spell_links[0]))
         print(getSpellInfo(srd_spell_links[1]))
+        print(getSpellInfo(srd_spell_links[10]))
         print(getSpellInfo(srd_spell_links[33]))
         print(getSpellInfo(srd_spell_links[64]))
         print(getSpellInfo(srd_spell_links[260]))

--- a/process-spells-from-export.py
+++ b/process-spells-from-export.py
@@ -1,0 +1,50 @@
+import os
+import re
+from bs4 import BeautifulSoup
+
+
+normalizationRegex = re.compile('[^a-z\-]')
+
+
+def normalizeString(string: str):
+    return normalizationRegex.sub('', string.lower().strip().replace(' ', '-'))
+
+
+class SpellLink:
+    def __init__(self, soup_link):
+        self.name = soup_link.string
+        self.id = normalizeString(self.name)
+        self.href = soup_link.get('href')
+        self.subLink = None
+
+    def addSubLink(self, soup_link):
+        self.subLink = soup_link.get('href')
+
+    def __str__(self):
+        return f"{self.name}"
+
+    def __repr__(self):
+        return f"({self.name}, {self.id}, {self.href}, {self.subLink})"
+
+
+rel_path_to_parts_folder = os.path.join(
+    "exported-from-adobe", "SRD5.1-CCBY4.0_License_live links_files")
+file_name_for_spell_descriptions = "part646.htm"
+path_for_spell_descriptions = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), rel_path_to_parts_folder, file_name_for_spell_descriptions)
+
+with open(path_for_spell_descriptions) as fp:
+    soup = BeautifulSoup(fp, 'lxml')
+
+srd_spell_links: list[SpellLink] = []
+for link in soup.find_all('a'):
+    if link.get('class') == None:
+        continue
+    elif link.get('class') == ['toc0']:
+        srd_spell_links.append(SpellLink(link))
+    elif link.get('class') == ['toc1']:
+        srd_spell_links[-1].addSubLink(link)
+    else:
+        continue
+
+print(srd_spell_links)

--- a/spells/spells.json
+++ b/spells/spells.json
@@ -1,0 +1,1916 @@
+{
+  "acid-arrow": {
+    "name": "Acid Arrow",
+    "ritual": false,
+    "level": 2,
+    "school": "Evocation"
+  },
+  "acid-splash": {
+    "name": "Acid Splash",
+    "ritual": false,
+    "level": 0,
+    "school": "Conjuration"
+  },
+  "aid": {
+    "name": "Aid",
+    "ritual": false,
+    "level": 2,
+    "school": "Abjuration"
+  },
+  "alarm": {
+    "name": "Alarm",
+    "ritual": true,
+    "level": 1,
+    "school": "Abjuration"
+  },
+  "alter-self": {
+    "name": "Alter Self",
+    "ritual": false,
+    "level": 2,
+    "school": "Transmutation"
+  },
+  "animal-friendship": {
+    "name": "Animal Friendship",
+    "ritual": false,
+    "level": 1,
+    "school": "Enchantment"
+  },
+  "animal-messenger": {
+    "name": "Animal Messenger",
+    "ritual": true,
+    "level": 2,
+    "school": "Enchantment"
+  },
+  "animal-shapes": {
+    "name": "Animal Shapes",
+    "ritual": false,
+    "level": 8,
+    "school": "Transmutation"
+  },
+  "animate-dead": {
+    "name": "Animate Dead",
+    "ritual": false,
+    "level": 3,
+    "school": "Necromancy"
+  },
+  "animate-objects": {
+    "name": "Animate Objects",
+    "ritual": false,
+    "level": 5,
+    "school": "Transmutation"
+  },
+  "antilife-shell": {
+    "name": "Antilife Shell",
+    "ritual": false,
+    "level": 5,
+    "school": "Abjuration"
+  },
+  "antimagic-field": {
+    "name": "Antimagic Field",
+    "ritual": false,
+    "level": 8,
+    "school": "Abjuration"
+  },
+  "antipathy-sympathy": {
+    "name": "Antipathy/Sympathy",
+    "ritual": false,
+    "level": 8,
+    "school": "Enchantment"
+  },
+  "arcane-eye": {
+    "name": "Arcane Eye",
+    "ritual": false,
+    "level": 4,
+    "school": "Divination"
+  },
+  "arcane-hand": {
+    "name": "Arcane Hand",
+    "ritual": false,
+    "level": 5,
+    "school": "Evocation"
+  },
+  "arcane-lock": {
+    "name": "Arcane Lock",
+    "ritual": false,
+    "level": 2,
+    "school": "Abjuration"
+  },
+  "arcane-sword": {
+    "name": "Arcane Sword",
+    "ritual": false,
+    "level": 7,
+    "school": "Evocation"
+  },
+  "arcanists-magic-aura": {
+    "name": "Arcanist\u2019s Magic Aura",
+    "ritual": false,
+    "level": 2,
+    "school": "Illusion"
+  },
+  "astral-projection": {
+    "name": "Astral Projection",
+    "ritual": false,
+    "level": 9,
+    "school": "Necromancy"
+  },
+  "augury": {
+    "name": "Augury",
+    "ritual": true,
+    "level": 2,
+    "school": "Divination"
+  },
+  "awaken": {
+    "name": "Awaken",
+    "ritual": false,
+    "level": 5,
+    "school": "Transmutation"
+  },
+  "bane": {
+    "name": "Bane",
+    "ritual": false,
+    "level": 1,
+    "school": "Enchantment"
+  },
+  "banishment": {
+    "name": "Banishment",
+    "ritual": false,
+    "level": 4,
+    "school": "Abjuration"
+  },
+  "barkskin": {
+    "name": "Barkskin",
+    "ritual": false,
+    "level": 2,
+    "school": "Transmutation"
+  },
+  "beacon-of-hope": {
+    "name": "Beacon of Hope",
+    "ritual": false,
+    "level": 3,
+    "school": "Abjuration"
+  },
+  "bestow-curse": {
+    "name": "Bestow Curse",
+    "ritual": false,
+    "level": 3,
+    "school": "Necromancy"
+  },
+  "black-tentacles": {
+    "name": "Black Tentacles",
+    "ritual": false,
+    "level": 4,
+    "school": "Conjuration"
+  },
+  "blade-barrier": {
+    "name": "Blade Barrier",
+    "ritual": false,
+    "level": 6,
+    "school": "Evocation"
+  },
+  "bless": {
+    "name": "Bless",
+    "ritual": false,
+    "level": 1,
+    "school": "Enchantment"
+  },
+  "blight": {
+    "name": "Blight",
+    "ritual": false,
+    "level": 4,
+    "school": "Necromancy"
+  },
+  "blindness-deafness": {
+    "name": "Blindness/Deafness",
+    "ritual": false,
+    "level": 2,
+    "school": "Necromancy"
+  },
+  "blink": {
+    "name": "Blink",
+    "ritual": false,
+    "level": 3,
+    "school": "Transmutation"
+  },
+  "blur": {
+    "name": "Blur",
+    "ritual": false,
+    "level": 2,
+    "school": "Illusion"
+  },
+  "branding-smite": {
+    "name": "Branding Smite",
+    "ritual": false,
+    "level": 2,
+    "school": "Evocation"
+  },
+  "burning-hands": {
+    "name": "Burning Hands",
+    "ritual": false,
+    "level": 1,
+    "school": "Evocation"
+  },
+  "call-lightning": {
+    "name": "Call Lightning",
+    "ritual": false,
+    "level": 3,
+    "school": "Conjuration"
+  },
+  "calm-emotions": {
+    "name": "Calm Emotions",
+    "ritual": false,
+    "level": 2,
+    "school": "Enchantment"
+  },
+  "chain-lightning": {
+    "name": "Chain Lightning",
+    "ritual": false,
+    "level": 6,
+    "school": "Evocation"
+  },
+  "charm-person": {
+    "name": "Charm Person",
+    "ritual": false,
+    "level": 1,
+    "school": "Enchantment"
+  },
+  "chill-touch": {
+    "name": "Chill Touch",
+    "ritual": false,
+    "level": 0,
+    "school": "Necromancy"
+  },
+  "circle-of-death": {
+    "name": "Circle of Death",
+    "ritual": false,
+    "level": 6,
+    "school": "Necromancy"
+  },
+  "clairvoyance": {
+    "name": "Clairvoyance",
+    "ritual": false,
+    "level": 3,
+    "school": "Divination"
+  },
+  "clone": {
+    "name": "Clone",
+    "ritual": false,
+    "level": 8,
+    "school": "Necromancy"
+  },
+  "cloudkill": {
+    "name": "Cloudkill",
+    "ritual": false,
+    "level": 5,
+    "school": "Conjuration"
+  },
+  "color-spray": {
+    "name": "Color Spray",
+    "ritual": false,
+    "level": 1,
+    "school": "Illusion"
+  },
+  "command": {
+    "name": "Command",
+    "ritual": false,
+    "level": 1,
+    "school": "Enchantment"
+  },
+  "commune": {
+    "name": "Commune",
+    "ritual": true,
+    "level": 5,
+    "school": "Divination"
+  },
+  "commune-with-nature": {
+    "name": "Commune with Nature",
+    "ritual": true,
+    "level": 5,
+    "school": "Divination"
+  },
+  "comprehend-languages": {
+    "name": "Comprehend Languages",
+    "ritual": true,
+    "level": 1,
+    "school": "Divination"
+  },
+  "compulsion": {
+    "name": "Compulsion",
+    "ritual": false,
+    "level": 4,
+    "school": "Enchantment"
+  },
+  "cone-of-cold": {
+    "name": "Cone of Cold",
+    "ritual": false,
+    "level": 5,
+    "school": "Evocation"
+  },
+  "confusion": {
+    "name": "Confusion",
+    "ritual": false,
+    "level": 4,
+    "school": "Enchantment"
+  },
+  "conjure-animals": {
+    "name": "Conjure Animals",
+    "ritual": false,
+    "level": 3,
+    "school": "Conjuration"
+  },
+  "conjure-celestial": {
+    "name": "Conjure Celestial",
+    "ritual": false,
+    "level": 7,
+    "school": "Conjuration"
+  },
+  "conjure-elemental": {
+    "name": "Conjure Elemental",
+    "ritual": false,
+    "level": 5,
+    "school": "Conjuration"
+  },
+  "conjure-fey": {
+    "name": "Conjure Fey",
+    "ritual": false,
+    "level": 6,
+    "school": "Conjuration"
+  },
+  "conjure-minor-elementals": {
+    "name": "Conjure Minor Elementals",
+    "ritual": false,
+    "level": 4,
+    "school": "Conjuration"
+  },
+  "conjure-woodland-beings": {
+    "name": "Conjure Woodland Beings",
+    "ritual": false,
+    "level": 4,
+    "school": "Conjuration"
+  },
+  "contact-other-plane": {
+    "name": "Contact Other Plane",
+    "ritual": true,
+    "level": 5,
+    "school": "Divination"
+  },
+  "contagion": {
+    "name": "Contagion",
+    "ritual": false,
+    "level": 5,
+    "school": "Necromancy"
+  },
+  "contingency": {
+    "name": "Contingency",
+    "ritual": false,
+    "level": 6,
+    "school": "Evocation"
+  },
+  "continual-flame": {
+    "name": "Continual Flame",
+    "ritual": false,
+    "level": 2,
+    "school": "Evocation"
+  },
+  "control-water": {
+    "name": "Control Water",
+    "ritual": false,
+    "level": 4,
+    "school": "Transmutation"
+  },
+  "control-weather": {
+    "name": "Control Weather",
+    "ritual": false,
+    "level": 8,
+    "school": "Transmutation"
+  },
+  "counterspell": {
+    "name": "Counterspell",
+    "ritual": false,
+    "level": 3,
+    "school": "Abjuration"
+  },
+  "create-food-and-water": {
+    "name": "Create Food and Water",
+    "ritual": false,
+    "level": 3,
+    "school": "Conjuration"
+  },
+  "create-or-destroy-water": {
+    "name": "Create or Destroy Water",
+    "ritual": false,
+    "level": 1,
+    "school": "Transmutation"
+  },
+  "create-undead": {
+    "name": "Create Undead",
+    "ritual": false,
+    "level": 6,
+    "school": "Necromancy"
+  },
+  "creation": {
+    "name": "Creation",
+    "ritual": false,
+    "level": 5,
+    "school": "Illusion"
+  },
+  "cure-wounds": {
+    "name": "Cure Wounds",
+    "ritual": false,
+    "level": 1,
+    "school": "Evocation"
+  },
+  "dancing-lights": {
+    "name": "Dancing Lights",
+    "ritual": false,
+    "level": 0,
+    "school": "Evocation"
+  },
+  "darkness": {
+    "name": "Darkness",
+    "ritual": false,
+    "level": 2,
+    "school": "Evocation"
+  },
+  "darkvision": {
+    "name": "Darkvision",
+    "ritual": false,
+    "level": 2,
+    "school": "Transmutation"
+  },
+  "daylight": {
+    "name": "Daylight",
+    "ritual": false,
+    "level": 3,
+    "school": "Evocation"
+  },
+  "death-ward": {
+    "name": "Death Ward",
+    "ritual": false,
+    "level": 4,
+    "school": "Abjuration"
+  },
+  "delayed-blast-fireball": {
+    "name": "Delayed Blast Fireball",
+    "ritual": false,
+    "level": 7,
+    "school": "Evocation"
+  },
+  "demiplane": {
+    "name": "Demiplane",
+    "ritual": false,
+    "level": 8,
+    "school": "Conjuration"
+  },
+  "detect-evil-and-good": {
+    "name": "Detect Evil and Good",
+    "ritual": false,
+    "level": 1,
+    "school": "Divination"
+  },
+  "detect-magic": {
+    "name": "Detect Magic",
+    "ritual": true,
+    "level": 1,
+    "school": "Divination"
+  },
+  "detect-poison-and-disease": {
+    "name": "Detect Poison and Disease",
+    "ritual": true,
+    "level": 1,
+    "school": "Divination"
+  },
+  "detect-thoughts": {
+    "name": "Detect Thoughts",
+    "ritual": false,
+    "level": 2,
+    "school": "Divination"
+  },
+  "dimension-door": {
+    "name": "Dimension Door",
+    "ritual": false,
+    "level": 4,
+    "school": "Conjuration"
+  },
+  "disguise-self": {
+    "name": "Disguise Self",
+    "ritual": false,
+    "level": 1,
+    "school": "Illusion"
+  },
+  "disintegrate": {
+    "name": "Disintegrate",
+    "ritual": false,
+    "level": 6,
+    "school": "Transmutation"
+  },
+  "dispel-evil-and-good": {
+    "name": "Dispel Evil and Good",
+    "ritual": false,
+    "level": 5,
+    "school": "Abjuration"
+  },
+  "dispel-magic": {
+    "name": "Dispel Magic",
+    "ritual": false,
+    "level": 3,
+    "school": "Abjuration"
+  },
+  "divination": {
+    "name": "Divination",
+    "ritual": true,
+    "level": 4,
+    "school": "Divination"
+  },
+  "divine-favor": {
+    "name": "Divine Favor",
+    "ritual": false,
+    "level": 1,
+    "school": "Evocation"
+  },
+  "divine-word": {
+    "name": "Divine Word",
+    "ritual": false,
+    "level": 7,
+    "school": "Evocation"
+  },
+  "dominate-beast": {
+    "name": "Dominate Beast",
+    "ritual": false,
+    "level": 4,
+    "school": "Enchantment"
+  },
+  "dominate-monster": {
+    "name": "Dominate Monster",
+    "ritual": false,
+    "level": 8,
+    "school": "Enchantment"
+  },
+  "dominate-person": {
+    "name": "Dominate Person",
+    "ritual": false,
+    "level": 5,
+    "school": "Enchantment"
+  },
+  "dream": {
+    "name": "Dream",
+    "ritual": false,
+    "level": 5,
+    "school": "Illusion"
+  },
+  "druidcraft": {
+    "name": "Druidcraft",
+    "ritual": false,
+    "level": 0,
+    "school": "Transmutation"
+  },
+  "earthquake": {
+    "name": "Earthquake",
+    "ritual": false,
+    "level": 8,
+    "school": "Evocation"
+  },
+  "eldritch-blast": {
+    "name": "Eldritch Blast",
+    "ritual": false,
+    "level": 0,
+    "school": "Evocation"
+  },
+  "enhance-ability": {
+    "name": "Enhance Ability",
+    "ritual": false,
+    "level": 2,
+    "school": "Transmutation"
+  },
+  "enlarge-reduce": {
+    "name": "Enlarge/Reduce",
+    "ritual": false,
+    "level": 2,
+    "school": "Transmutation"
+  },
+  "entangle": {
+    "name": "Entangle",
+    "ritual": false,
+    "level": 1,
+    "school": "Conjuration"
+  },
+  "enthrall": {
+    "name": "Enthrall",
+    "ritual": false,
+    "level": 2,
+    "school": "Enchantment"
+  },
+  "etherealness": {
+    "name": "Etherealness",
+    "ritual": false,
+    "level": 7,
+    "school": "Transmutation"
+  },
+  "expeditious-retreat": {
+    "name": "Expeditious Retreat",
+    "ritual": false,
+    "level": 1,
+    "school": "Transmutation"
+  },
+  "eyebite": {
+    "name": "Eyebite",
+    "ritual": false,
+    "level": 6,
+    "school": "Necromancy"
+  },
+  "fabricate": {
+    "name": "Fabricate",
+    "ritual": false,
+    "level": 4,
+    "school": "Transmutation"
+  },
+  "faerie-fire": {
+    "name": "Faerie Fire",
+    "ritual": false,
+    "level": 1,
+    "school": "Evocation"
+  },
+  "faithful-hound": {
+    "name": "Faithful Hound",
+    "ritual": false,
+    "level": 4,
+    "school": "Conjuration"
+  },
+  "false-life": {
+    "name": "False Life",
+    "ritual": false,
+    "level": 1,
+    "school": "Necromancy"
+  },
+  "fear": {
+    "name": "Fear",
+    "ritual": false,
+    "level": 3,
+    "school": "Illusion"
+  },
+  "feather-fall": {
+    "name": "Feather Fall",
+    "ritual": false,
+    "level": 1,
+    "school": "Transmutation"
+  },
+  "feeblemind": {
+    "name": "Feeblemind",
+    "ritual": false,
+    "level": 8,
+    "school": "Enchantment"
+  },
+  "find-familiar": {
+    "name": "Find Familiar",
+    "ritual": true,
+    "level": 1,
+    "school": "Conjuration"
+  },
+  "find-steed": {
+    "name": "Find Steed",
+    "ritual": false,
+    "level": 2,
+    "school": "Conjuration"
+  },
+  "find-the-path": {
+    "name": "Find the Path",
+    "ritual": false,
+    "level": 6,
+    "school": "Divination"
+  },
+  "find-traps": {
+    "name": "Find Traps",
+    "ritual": false,
+    "level": 2,
+    "school": "Divination"
+  },
+  "finger-of-death": {
+    "name": "Finger of Death",
+    "ritual": false,
+    "level": 7,
+    "school": "Necromancy"
+  },
+  "fireball": {
+    "name": "Fireball",
+    "ritual": false,
+    "level": 3,
+    "school": "Evocation"
+  },
+  "fire-bolt": {
+    "name": "Fire Bolt",
+    "ritual": false,
+    "level": 0,
+    "school": "Evocation"
+  },
+  "fire-shield": {
+    "name": "Fire Shield",
+    "ritual": false,
+    "level": 4,
+    "school": "Evocation"
+  },
+  "fire-storm": {
+    "name": "Fire Storm",
+    "ritual": false,
+    "level": 7,
+    "school": "Evocation"
+  },
+  "flame-blade": {
+    "name": "Flame Blade",
+    "ritual": false,
+    "level": 2,
+    "school": "Evocation"
+  },
+  "flame-strike": {
+    "name": "Flame Strike",
+    "ritual": false,
+    "level": 5,
+    "school": "Evocation"
+  },
+  "flaming-sphere": {
+    "name": "Flaming Sphere",
+    "ritual": false,
+    "level": 2,
+    "school": "Conjuration"
+  },
+  "flesh-to-stone": {
+    "name": "Flesh to Stone",
+    "ritual": false,
+    "level": 6,
+    "school": "Transmutation"
+  },
+  "floating-disk": {
+    "name": "Floating Disk",
+    "ritual": true,
+    "level": 1,
+    "school": "Conjuration"
+  },
+  "fly": {
+    "name": "Fly",
+    "ritual": false,
+    "level": 3,
+    "school": "Transmutation"
+  },
+  "fog-cloud": {
+    "name": "Fog Cloud",
+    "ritual": false,
+    "level": 1,
+    "school": "Conjuration"
+  },
+  "forbiddance": {
+    "name": "Forbiddance",
+    "ritual": true,
+    "level": 6,
+    "school": "Abjuration"
+  },
+  "forcecage": {
+    "name": "Forcecage",
+    "ritual": false,
+    "level": 7,
+    "school": "Evocation"
+  },
+  "foresight": {
+    "name": "Foresight",
+    "ritual": false,
+    "level": 9,
+    "school": "Divination"
+  },
+  "freedom-of-movement": {
+    "name": "Freedom of Movement",
+    "ritual": false,
+    "level": 4,
+    "school": "Abjuration"
+  },
+  "freezing-sphere": {
+    "name": "Freezing Sphere",
+    "ritual": false,
+    "level": 6,
+    "school": "Evocation"
+  },
+  "gaseous-form": {
+    "name": "Gaseous Form",
+    "ritual": false,
+    "level": 3,
+    "school": "Transmutation"
+  },
+  "gate": {
+    "name": "Gate",
+    "ritual": false,
+    "level": 9,
+    "school": "Conjuration"
+  },
+  "geas": {
+    "name": "Geas",
+    "ritual": false,
+    "level": 5,
+    "school": "Enchantment"
+  },
+  "gentle-repose": {
+    "name": "Gentle Repose",
+    "ritual": true,
+    "level": 2,
+    "school": "Necromancy"
+  },
+  "giant-insect": {
+    "name": "Giant Insect",
+    "ritual": false,
+    "level": 4,
+    "school": "Transmutation"
+  },
+  "glibness": {
+    "name": "Glibness",
+    "ritual": false,
+    "level": 8,
+    "school": "Transmutation"
+  },
+  "globe-of-invulnerability": {
+    "name": "Globe of Invulnerability",
+    "ritual": false,
+    "level": 6,
+    "school": "Abjuration"
+  },
+  "glyph-of-warding": {
+    "name": "Glyph of Warding",
+    "ritual": false,
+    "level": 3,
+    "school": "Abjuration"
+  },
+  "goodberry": {
+    "name": "Goodberry",
+    "ritual": false,
+    "level": 1,
+    "school": "Transmutation"
+  },
+  "grease": {
+    "name": "Grease",
+    "ritual": false,
+    "level": 1,
+    "school": "Conjuration"
+  },
+  "greater-invisibility": {
+    "name": "Greater Invisibility",
+    "ritual": false,
+    "level": 4,
+    "school": "Illusion"
+  },
+  "greater-restoration": {
+    "name": "Greater Restoration",
+    "ritual": false,
+    "level": 5,
+    "school": "Abjuration"
+  },
+  "guardian-of-faith": {
+    "name": "Guardian of Faith",
+    "ritual": false,
+    "level": 4,
+    "school": "Conjuration"
+  },
+  "guards-and-wards": {
+    "name": "Guards and Wards",
+    "ritual": false,
+    "level": 6,
+    "school": "Abjuration"
+  },
+  "guidance": {
+    "name": "Guidance",
+    "ritual": false,
+    "level": 0,
+    "school": "Divination"
+  },
+  "guiding-bolt": {
+    "name": "Guiding Bolt",
+    "ritual": false,
+    "level": 1,
+    "school": "Evocation"
+  },
+  "gust-of-wind": {
+    "name": "Gust of Wind",
+    "ritual": false,
+    "level": 2,
+    "school": "Evocation"
+  },
+  "hallow": {
+    "name": "Hallow",
+    "ritual": false,
+    "level": 5,
+    "school": "Evocation"
+  },
+  "hallucinatory-terrain": {
+    "name": "Hallucinatory Terrain",
+    "ritual": false,
+    "level": 4,
+    "school": "Illusion"
+  },
+  "harm": {
+    "name": "Harm",
+    "ritual": false,
+    "level": 6,
+    "school": "Necromancy"
+  },
+  "haste": {
+    "name": "Haste",
+    "ritual": false,
+    "level": 3,
+    "school": "Transmutation"
+  },
+  "heal": {
+    "name": "Heal",
+    "ritual": false,
+    "level": 6,
+    "school": "Evocation"
+  },
+  "healing-word": {
+    "name": "Healing Word",
+    "ritual": false,
+    "level": 1,
+    "school": "Evocation"
+  },
+  "heat-metal": {
+    "name": "Heat Metal",
+    "ritual": false,
+    "level": 2,
+    "school": "Transmutation"
+  },
+  "hellish-rebuke": {
+    "name": "Hellish Rebuke",
+    "ritual": false,
+    "level": 1,
+    "school": "Evocation"
+  },
+  "heroes-feast": {
+    "name": "Heroes\u2019 Feast",
+    "ritual": false,
+    "level": 6,
+    "school": "Conjuration"
+  },
+  "heroism": {
+    "name": "Heroism",
+    "ritual": false,
+    "level": 1,
+    "school": "Enchantment"
+  },
+  "hideous-laughter": {
+    "name": "Hideous Laughter",
+    "ritual": false,
+    "level": 1,
+    "school": "Enchantment"
+  },
+  "hold-monster": {
+    "name": "Hold Monster",
+    "ritual": false,
+    "level": 5,
+    "school": "Enchantment"
+  },
+  "hold-person": {
+    "name": "Hold Person",
+    "ritual": false,
+    "level": 2,
+    "school": "Enchantment"
+  },
+  "holy-aura": {
+    "name": "Holy Aura",
+    "ritual": false,
+    "level": 8,
+    "school": "Abjuration"
+  },
+  "hunters-mark": {
+    "name": "Hunter\u2019s Mark",
+    "ritual": false,
+    "level": 1,
+    "school": "Divination"
+  },
+  "hypnotic-pattern": {
+    "name": "Hypnotic Pattern",
+    "ritual": false,
+    "level": 3,
+    "school": "Illusion"
+  },
+  "ice-storm": {
+    "name": "Ice Storm",
+    "ritual": false,
+    "level": 4,
+    "school": "Evocation"
+  },
+  "identify": {
+    "name": "Identify",
+    "ritual": true,
+    "level": 1,
+    "school": "Divination"
+  },
+  "illusory-script": {
+    "name": "Illusory Script",
+    "ritual": true,
+    "level": 1,
+    "school": "Illusion"
+  },
+  "imprisonment": {
+    "name": "Imprisonment",
+    "ritual": false,
+    "level": 9,
+    "school": "Abjuration"
+  },
+  "incendiary-cloud": {
+    "name": "Incendiary Cloud",
+    "ritual": false,
+    "level": 8,
+    "school": "Conjuration"
+  },
+  "inflict-wounds": {
+    "name": "Inflict Wounds",
+    "ritual": false,
+    "level": 1,
+    "school": "Necromancy"
+  },
+  "insect-plague": {
+    "name": "Insect Plague",
+    "ritual": false,
+    "level": 5,
+    "school": "Conjuration"
+  },
+  "instant-summons": {
+    "name": "Instant Summons",
+    "ritual": true,
+    "level": 6,
+    "school": "Conjuration"
+  },
+  "invisibility": {
+    "name": "Invisibility",
+    "ritual": false,
+    "level": 2,
+    "school": "Illusion"
+  },
+  "irresistible-dance": {
+    "name": "Irresistible Dance",
+    "ritual": false,
+    "level": 6,
+    "school": "Enchantment"
+  },
+  "jump": {
+    "name": "Jump",
+    "ritual": false,
+    "level": 1,
+    "school": "Transmutation"
+  },
+  "knock": {
+    "name": "Knock",
+    "ritual": false,
+    "level": 2,
+    "school": "Transmutation"
+  },
+  "legend-lore": {
+    "name": "Legend Lore",
+    "ritual": false,
+    "level": 5,
+    "school": "Divination"
+  },
+  "lesser-restoration": {
+    "name": "Lesser Restoration",
+    "ritual": false,
+    "level": 2,
+    "school": "Abjuration"
+  },
+  "levitate": {
+    "name": "Levitate",
+    "ritual": false,
+    "level": 2,
+    "school": "Transmutation"
+  },
+  "light": {
+    "name": "Light",
+    "ritual": false,
+    "level": 0,
+    "school": "Evocation"
+  },
+  "lightning-bolt": {
+    "name": "Lightning Bolt",
+    "ritual": false,
+    "level": 3,
+    "school": "Evocation"
+  },
+  "locate-animals-or-plants": {
+    "name": "Locate Animals or Plants",
+    "ritual": true,
+    "level": 2,
+    "school": "Divination"
+  },
+  "locate-creature": {
+    "name": "Locate Creature",
+    "ritual": false,
+    "level": 4,
+    "school": "Divination"
+  },
+  "locate-object": {
+    "name": "Locate Object",
+    "ritual": false,
+    "level": 2,
+    "school": "Divination"
+  },
+  "longstrider": {
+    "name": "Longstrider",
+    "ritual": false,
+    "level": 1,
+    "school": "Transmutation"
+  },
+  "mage-armor": {
+    "name": "Mage Armor",
+    "ritual": false,
+    "level": 1,
+    "school": "Abjuration"
+  },
+  "mage-hand": {
+    "name": "Mage Hand",
+    "ritual": false,
+    "level": 0,
+    "school": "Conjuration"
+  },
+  "magic-circle": {
+    "name": "Magic Circle",
+    "ritual": false,
+    "level": 3,
+    "school": "Abjuration"
+  },
+  "magic-jar": {
+    "name": "Magic Jar",
+    "ritual": false,
+    "level": 6,
+    "school": "Necromancy"
+  },
+  "magic-missile": {
+    "name": "Magic Missile",
+    "ritual": false,
+    "level": 1,
+    "school": "Evocation"
+  },
+  "magic-mouth": {
+    "name": "Magic Mouth",
+    "ritual": true,
+    "level": 2,
+    "school": "Illusion"
+  },
+  "magic-weapon": {
+    "name": "Magic Weapon",
+    "ritual": false,
+    "level": 2,
+    "school": "Transmutation"
+  },
+  "magnificent-mansion": {
+    "name": "Magnificent Mansion",
+    "ritual": false,
+    "level": 7,
+    "school": "Conjuration"
+  },
+  "major-image": {
+    "name": "Major Image",
+    "ritual": false,
+    "level": 3,
+    "school": "Illusion"
+  },
+  "mass-cure-wounds": {
+    "name": "Mass Cure Wounds",
+    "ritual": false,
+    "level": 5,
+    "school": "Evocation"
+  },
+  "mass-heal": {
+    "name": "Mass Heal",
+    "ritual": false,
+    "level": 9,
+    "school": "Evocation"
+  },
+  "mass-healing-word": {
+    "name": "Mass Healing Word",
+    "ritual": false,
+    "level": 3,
+    "school": "Evocation"
+  },
+  "mass-suggestion": {
+    "name": "Mass Suggestion",
+    "ritual": false,
+    "level": 6,
+    "school": "Enchantment"
+  },
+  "maze": {
+    "name": "Maze",
+    "ritual": false,
+    "level": 8,
+    "school": "Conjuration"
+  },
+  "meld-into-stone": {
+    "name": "Meld into Stone",
+    "ritual": true,
+    "level": 3,
+    "school": "Transmutation"
+  },
+  "mending": {
+    "name": "Mending",
+    "ritual": false,
+    "level": 0,
+    "school": "Transmutation"
+  },
+  "message": {
+    "name": "Message",
+    "ritual": false,
+    "level": 0,
+    "school": "Transmutation"
+  },
+  "meteor-swarm": {
+    "name": "Meteor Swarm",
+    "ritual": false,
+    "level": 9,
+    "school": "Evocation"
+  },
+  "mind-blank": {
+    "name": "Mind Blank",
+    "ritual": false,
+    "level": 8,
+    "school": "Abjuration"
+  },
+  "minor-illusion": {
+    "name": "Minor Illusion",
+    "ritual": false,
+    "level": 0,
+    "school": "Illusion"
+  },
+  "mirage-arcane": {
+    "name": "Mirage Arcane",
+    "ritual": false,
+    "level": 7,
+    "school": "Illusion"
+  },
+  "mirror-image": {
+    "name": "Mirror Image",
+    "ritual": false,
+    "level": 2,
+    "school": "Illusion"
+  },
+  "mislead": {
+    "name": "Mislead",
+    "ritual": false,
+    "level": 5,
+    "school": "Illusion"
+  },
+  "misty-step": {
+    "name": "Misty Step",
+    "ritual": false,
+    "level": 2,
+    "school": "Conjuration"
+  },
+  "modify-memory": {
+    "name": "Modify Memory",
+    "ritual": false,
+    "level": 5,
+    "school": "Enchantment"
+  },
+  "moonbeam": {
+    "name": "Moonbeam",
+    "ritual": false,
+    "level": 2,
+    "school": "Evocation"
+  },
+  "move-earth": {
+    "name": "Move Earth",
+    "ritual": false,
+    "level": 6,
+    "school": "Transmutation"
+  },
+  "nondetection": {
+    "name": "Nondetection",
+    "ritual": false,
+    "level": 3,
+    "school": "Abjuration"
+  },
+  "pass-without-trace": {
+    "name": "Pass without Trace",
+    "ritual": false,
+    "level": 2,
+    "school": "Abjuration"
+  },
+  "passwall": {
+    "name": "Passwall",
+    "ritual": false,
+    "level": 5,
+    "school": "Transmutation"
+  },
+  "phantasmal-killer": {
+    "name": "Phantasmal Killer",
+    "ritual": false,
+    "level": 4,
+    "school": "Illusion"
+  },
+  "phantom-steed": {
+    "name": "Phantom Steed",
+    "ritual": true,
+    "level": 3,
+    "school": "Illusion"
+  },
+  "planar-ally": {
+    "name": "Planar Ally",
+    "ritual": false,
+    "level": 6,
+    "school": "Conjuration"
+  },
+  "planar-binding": {
+    "name": "Planar Binding",
+    "ritual": false,
+    "level": 5,
+    "school": "Abjuration"
+  },
+  "plane-shift": {
+    "name": "Plane Shift",
+    "ritual": false,
+    "level": 7,
+    "school": "Conjuration"
+  },
+  "plant-growth": {
+    "name": "Plant Growth",
+    "ritual": false,
+    "level": 3,
+    "school": "Transmutation"
+  },
+  "poison-spray": {
+    "name": "Poison Spray",
+    "ritual": false,
+    "level": 0,
+    "school": "Conjuration"
+  },
+  "polymorph": {
+    "name": "Polymorph",
+    "ritual": false,
+    "level": 4,
+    "school": "Transmutation"
+  },
+  "power-word-kill": {
+    "name": "Power Word Kill",
+    "ritual": false,
+    "level": 9,
+    "school": "Enchantment"
+  },
+  "power-word-stun": {
+    "name": "Power Word Stun",
+    "ritual": false,
+    "level": 8,
+    "school": "Enchantment"
+  },
+  "prayer-of-healing": {
+    "name": "Prayer of Healing",
+    "ritual": false,
+    "level": 2,
+    "school": "Evocation"
+  },
+  "prestidigitation": {
+    "name": "Prestidigitation",
+    "ritual": false,
+    "level": 0,
+    "school": "Transmutation"
+  },
+  "prismatic-spray": {
+    "name": "Prismatic Spray",
+    "ritual": false,
+    "level": 7,
+    "school": "Evocation"
+  },
+  "prismatic-wall": {
+    "name": "Prismatic Wall",
+    "ritual": false,
+    "level": 9,
+    "school": "Abjuration"
+  },
+  "private-sanctum": {
+    "name": "Private Sanctum",
+    "ritual": false,
+    "level": 4,
+    "school": "Abjuration"
+  },
+  "produce-flame": {
+    "name": "Produce Flame",
+    "ritual": false,
+    "level": 0,
+    "school": "Conjuration"
+  },
+  "programmed-illusion": {
+    "name": "Programmed Illusion",
+    "ritual": false,
+    "level": 6,
+    "school": "Illusion"
+  },
+  "project-image": {
+    "name": "Project Image",
+    "ritual": false,
+    "level": 7,
+    "school": "Illusion"
+  },
+  "protection-from-energy": {
+    "name": "Protection from Energy",
+    "ritual": false,
+    "level": 3,
+    "school": "Abjuration"
+  },
+  "protection-from-evil-and-good": {
+    "name": "Protection from Evil and Good",
+    "ritual": false,
+    "level": 1,
+    "school": "Abjuration"
+  },
+  "protection-from-poison": {
+    "name": "Protection from Poison",
+    "ritual": false,
+    "level": 2,
+    "school": "Abjuration"
+  },
+  "purify-food-and-drink": {
+    "name": "Purify Food and Drink",
+    "ritual": true,
+    "level": 1,
+    "school": "Transmutation"
+  },
+  "raise-dead": {
+    "name": "Raise Dead",
+    "ritual": false,
+    "level": 5,
+    "school": "Necromancy"
+  },
+  "ray-of-enfeeblement": {
+    "name": "Ray of Enfeeblement",
+    "ritual": false,
+    "level": 2,
+    "school": "Necromancy"
+  },
+  "ray-of-frost": {
+    "name": "Ray of Frost",
+    "ritual": false,
+    "level": 0,
+    "school": "Evocation"
+  },
+  "regenerate": {
+    "name": "Regenerate",
+    "ritual": false,
+    "level": 7,
+    "school": "Transmutation"
+  },
+  "reincarnate": {
+    "name": "Reincarnate",
+    "ritual": false,
+    "level": 5,
+    "school": "Transmutation"
+  },
+  "remove-curse": {
+    "name": "Remove Curse",
+    "ritual": false,
+    "level": 3,
+    "school": "Abjuration"
+  },
+  "resilient-sphere": {
+    "name": "Resilient Sphere",
+    "ritual": false,
+    "level": 4,
+    "school": "Evocation"
+  },
+  "resistance": {
+    "name": "Resistance",
+    "ritual": false,
+    "level": 0,
+    "school": "Abjuration"
+  },
+  "resurrection": {
+    "name": "Resurrection",
+    "ritual": false,
+    "level": 7,
+    "school": "Necromancy"
+  },
+  "reverse-gravity": {
+    "name": "Reverse Gravity",
+    "ritual": false,
+    "level": 7,
+    "school": "Transmutation"
+  },
+  "revivify": {
+    "name": "Revivify",
+    "ritual": false,
+    "level": 3,
+    "school": "Necromancy"
+  },
+  "rope-trick": {
+    "name": "Rope Trick",
+    "ritual": false,
+    "level": 2,
+    "school": "Transmutation"
+  },
+  "sacred-flame": {
+    "name": "Sacred Flame",
+    "ritual": false,
+    "level": 0,
+    "school": "Evocation"
+  },
+  "sanctuary": {
+    "name": "Sanctuary",
+    "ritual": false,
+    "level": 1,
+    "school": "Abjuration"
+  },
+  "scorching-ray": {
+    "name": "Scorching Ray",
+    "ritual": false,
+    "level": 2,
+    "school": "Evocation"
+  },
+  "scrying": {
+    "name": "Scrying",
+    "ritual": false,
+    "level": 5,
+    "school": "Divination"
+  },
+  "secret-chest": {
+    "name": "Secret Chest",
+    "ritual": false,
+    "level": 4,
+    "school": "Conjuration"
+  },
+  "see-invisibility": {
+    "name": "See Invisibility",
+    "ritual": false,
+    "level": 2,
+    "school": "Divination"
+  },
+  "seeming": {
+    "name": "Seeming",
+    "ritual": false,
+    "level": 5,
+    "school": "Illusion"
+  },
+  "sending": {
+    "name": "Sending",
+    "ritual": false,
+    "level": 3,
+    "school": "Evocation"
+  },
+  "sequester": {
+    "name": "Sequester",
+    "ritual": false,
+    "level": 7,
+    "school": "Transmutation"
+  },
+  "shapechange": {
+    "name": "Shapechange",
+    "ritual": false,
+    "level": 9,
+    "school": "Transmutation"
+  },
+  "shatter": {
+    "name": "Shatter",
+    "ritual": false,
+    "level": 2,
+    "school": "Evocation"
+  },
+  "shield": {
+    "name": "Shield",
+    "ritual": false,
+    "level": 1,
+    "school": "Abjuration"
+  },
+  "shield-of-faith": {
+    "name": "Shield of Faith",
+    "ritual": false,
+    "level": 1,
+    "school": "Abjuration"
+  },
+  "shillelagh": {
+    "name": "Shillelagh",
+    "ritual": false,
+    "level": 0,
+    "school": "Transmutation"
+  },
+  "shocking-grasp": {
+    "name": "Shocking Grasp",
+    "ritual": false,
+    "level": 0,
+    "school": "Evocation"
+  },
+  "silence": {
+    "name": "Silence",
+    "ritual": true,
+    "level": 2,
+    "school": "Illusion"
+  },
+  "silent-image": {
+    "name": "Silent Image",
+    "ritual": false,
+    "level": 1,
+    "school": "Illusion"
+  },
+  "simulacrum": {
+    "name": "Simulacrum",
+    "ritual": false,
+    "level": 7,
+    "school": "Illusion"
+  },
+  "sleep": {
+    "name": "Sleep",
+    "ritual": false,
+    "level": 1,
+    "school": "Enchantment"
+  },
+  "sleet-storm": {
+    "name": "Sleet Storm",
+    "ritual": false,
+    "level": 3,
+    "school": "Conjuration"
+  },
+  "slow": {
+    "name": "Slow",
+    "ritual": false,
+    "level": 3,
+    "school": "Transmutation"
+  },
+  "spare-the-dying": {
+    "name": "Spare the Dying",
+    "ritual": false,
+    "level": 0,
+    "school": "Necromancy"
+  },
+  "speak-with-animals": {
+    "name": "Speak with Animals",
+    "ritual": true,
+    "level": 1,
+    "school": "Divination"
+  },
+  "speak-with-dead": {
+    "name": "Speak with Dead",
+    "ritual": false,
+    "level": 3,
+    "school": "Necromancy"
+  },
+  "speak-with-plants": {
+    "name": "Speak with Plants",
+    "ritual": false,
+    "level": 3,
+    "school": "Transmutation"
+  },
+  "spider-climb": {
+    "name": "Spider Climb",
+    "ritual": false,
+    "level": 2,
+    "school": "Transmutation"
+  },
+  "spike-growth": {
+    "name": "Spike Growth",
+    "ritual": false,
+    "level": 2,
+    "school": "Transmutation"
+  },
+  "spirit-guardians": {
+    "name": "Spirit Guardians",
+    "ritual": false,
+    "level": 3,
+    "school": "Conjuration"
+  },
+  "spiritual-weapon": {
+    "name": "Spiritual Weapon",
+    "ritual": false,
+    "level": 2,
+    "school": "Evocation"
+  },
+  "stinking-cloud": {
+    "name": "Stinking Cloud",
+    "ritual": false,
+    "level": 3,
+    "school": "Conjuration"
+  },
+  "stone-shape": {
+    "name": "Stone Shape",
+    "ritual": false,
+    "level": 4,
+    "school": "Transmutation"
+  },
+  "stoneskin": {
+    "name": "Stoneskin",
+    "ritual": false,
+    "level": 4,
+    "school": "Abjuration"
+  },
+  "storm-of-vengeance": {
+    "name": "Storm of Vengeance",
+    "ritual": false,
+    "level": 9,
+    "school": "Conjuration"
+  },
+  "suggestion": {
+    "name": "Suggestion",
+    "ritual": false,
+    "level": 2,
+    "school": "Enchantment"
+  },
+  "sunbeam": {
+    "name": "Sunbeam",
+    "ritual": false,
+    "level": 6,
+    "school": "Evocation"
+  },
+  "sunburst": {
+    "name": "Sunburst",
+    "ritual": false,
+    "level": 8,
+    "school": "Evocation"
+  },
+  "symbol": {
+    "name": "Symbol",
+    "ritual": false,
+    "level": 7,
+    "school": "Abjuration"
+  },
+  "telekinesis": {
+    "name": "Telekinesis",
+    "ritual": false,
+    "level": 5,
+    "school": "Transmutation"
+  },
+  "telepathic-bond": {
+    "name": "Telepathic Bond",
+    "ritual": true,
+    "level": 5,
+    "school": "Divination"
+  },
+  "teleport": {
+    "name": "Teleport",
+    "ritual": false,
+    "level": 7,
+    "school": "Conjuration"
+  },
+  "teleportation-circle": {
+    "name": "Teleportation Circle",
+    "ritual": false,
+    "level": 5,
+    "school": "Conjuration"
+  },
+  "thaumaturgy": {
+    "name": "Thaumaturgy",
+    "ritual": false,
+    "level": 0,
+    "school": "Transmutation"
+  },
+  "thunderwave": {
+    "name": "Thunderwave",
+    "ritual": false,
+    "level": 1,
+    "school": "Evocation"
+  },
+  "time-stop": {
+    "name": "Time Stop",
+    "ritual": false,
+    "level": 9,
+    "school": "Transmutation"
+  },
+  "tiny-hut": {
+    "name": "Tiny Hut",
+    "ritual": true,
+    "level": 3,
+    "school": "Evocation"
+  },
+  "tongues": {
+    "name": "Tongues",
+    "ritual": false,
+    "level": 3,
+    "school": "Divination"
+  },
+  "transport-via-plants": {
+    "name": "Transport via Plants",
+    "ritual": false,
+    "level": 6,
+    "school": "Conjuration"
+  },
+  "tree-stride": {
+    "name": "Tree Stride",
+    "ritual": false,
+    "level": 5,
+    "school": "Conjuration"
+  },
+  "true-polymorph": {
+    "name": "True Polymorph",
+    "ritual": false,
+    "level": 9,
+    "school": "Transmutation"
+  },
+  "true-resurrection": {
+    "name": "True Resurrection",
+    "ritual": false,
+    "level": 9,
+    "school": "Necromancy"
+  },
+  "true-seeing": {
+    "name": "True Seeing",
+    "ritual": false,
+    "level": 6,
+    "school": "Divination"
+  },
+  "true-strike": {
+    "name": "True Strike",
+    "ritual": false,
+    "level": 0,
+    "school": "Divination"
+  },
+  "unseen-servant": {
+    "name": "Unseen Servant",
+    "ritual": true,
+    "level": 1,
+    "school": "Conjuration"
+  },
+  "vampiric-touch": {
+    "name": "Vampiric Touch",
+    "ritual": false,
+    "level": 3,
+    "school": "Necromancy"
+  },
+  "vicious-mockery": {
+    "name": "Vicious Mockery",
+    "ritual": false,
+    "level": 0,
+    "school": "Enchantment"
+  },
+  "wall-of-fire": {
+    "name": "Wall of Fire",
+    "ritual": false,
+    "level": 4,
+    "school": "Evocation"
+  },
+  "wall-of-force": {
+    "name": "Wall of Force",
+    "ritual": false,
+    "level": 5,
+    "school": "Evocation"
+  },
+  "wall-of-ice": {
+    "name": "Wall of Ice",
+    "ritual": false,
+    "level": 6,
+    "school": "Evocation"
+  },
+  "wall-of-stone": {
+    "name": "Wall of Stone",
+    "ritual": false,
+    "level": 5,
+    "school": "Evocation"
+  },
+  "wall-of-thorns": {
+    "name": "Wall of Thorns",
+    "ritual": false,
+    "level": 6,
+    "school": "Conjuration"
+  },
+  "warding-bond": {
+    "name": "Warding Bond",
+    "ritual": false,
+    "level": 2,
+    "school": "Abjuration"
+  },
+  "water-breathing": {
+    "name": "Water Breathing",
+    "ritual": true,
+    "level": 3,
+    "school": "Transmutation"
+  },
+  "water-walk": {
+    "name": "Water Walk",
+    "ritual": true,
+    "level": 3,
+    "school": "Transmutation"
+  },
+  "web": {
+    "name": "Web",
+    "ritual": false,
+    "level": 2,
+    "school": "Conjuration"
+  },
+  "weird": {
+    "name": "Weird",
+    "ritual": false,
+    "level": 9,
+    "school": "Illusion"
+  },
+  "wind-walk": {
+    "name": "Wind Walk",
+    "ritual": false,
+    "level": 6,
+    "school": "Transmutation"
+  },
+  "wind-wall": {
+    "name": "Wind Wall",
+    "ritual": false,
+    "level": 3,
+    "school": "Evocation"
+  },
+  "wish": {
+    "name": "Wish",
+    "ritual": false,
+    "level": 9,
+    "school": "Conjuration"
+  },
+  "word-of-recall": {
+    "name": "Word of Recall",
+    "ritual": false,
+    "level": 6,
+    "school": "Conjuration"
+  },
+  "zone-of-truth": {
+    "name": "Zone of Truth",
+    "ritual": false,
+    "level": 2,
+    "school": "Enchantment"
+  }
+}

--- a/spells/spells.json
+++ b/spells/spells.json
@@ -1823,7 +1823,7 @@
     "name": "Shield",
     "level": 1,
     "school": "Abjuration",
-    "castingTime": "1 reaction, which you take when you are hit by an attack or targeted by the",
+    "castingTime": "1 reaction, which you take when you are hit by an attack or targeted by the magic missile spell",
     "ritual": false
   },
   "shield-of-faith": {

--- a/spells/spells.json
+++ b/spells/spells.json
@@ -4,2232 +4,2551 @@
     "level": 2,
     "school": "Evocation",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "90 feet"
   },
   "acid-splash": {
     "name": "Acid Splash",
     "level": 0,
     "school": "Conjuration",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "60 feet"
   },
   "aid": {
     "name": "Aid",
     "level": 2,
     "school": "Abjuration",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "30 feet"
   },
   "alarm": {
     "name": "Alarm",
     "level": 1,
     "school": "Abjuration",
     "castingTime": "1 minute",
-    "ritual": true
+    "ritual": true,
+    "range": "30 feet"
   },
   "alter-self": {
     "name": "Alter Self",
     "level": 2,
     "school": "Transmutation",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "Self"
   },
   "animal-friendship": {
     "name": "Animal Friendship",
     "level": 1,
     "school": "Enchantment",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "30 feet"
   },
   "animal-messenger": {
     "name": "Animal Messenger",
     "level": 2,
     "school": "Enchantment",
     "castingTime": "1 action",
-    "ritual": true
+    "ritual": true,
+    "range": "30 feet"
   },
   "animal-shapes": {
     "name": "Animal Shapes",
     "level": 8,
     "school": "Transmutation",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "30 feet"
   },
   "animate-dead": {
     "name": "Animate Dead",
     "level": 3,
     "school": "Necromancy",
     "castingTime": "1 minute",
-    "ritual": false
+    "ritual": false,
+    "range": "10 feet"
   },
   "animate-objects": {
     "name": "Animate Objects",
     "level": 5,
     "school": "Transmutation",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "120 feet"
   },
   "antilife-shell": {
     "name": "Antilife Shell",
     "level": 5,
     "school": "Abjuration",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "Self (10-foot radius)"
   },
   "antimagic-field": {
     "name": "Antimagic Field",
     "level": 8,
     "school": "Abjuration",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "Self (10-foot-radius sphere)"
   },
   "antipathy-sympathy": {
     "name": "Antipathy/Sympathy",
     "level": 8,
     "school": "Enchantment",
     "castingTime": "1 hour",
-    "ritual": false
+    "ritual": false,
+    "range": "60 feet"
   },
   "arcane-eye": {
     "name": "Arcane Eye",
     "level": 4,
     "school": "Divination",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "30 feet"
   },
   "arcane-hand": {
     "name": "Arcane Hand",
     "level": 5,
     "school": "Evocation",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "120 feet"
   },
   "arcane-lock": {
     "name": "Arcane Lock",
     "level": 2,
     "school": "Abjuration",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "Touch"
   },
   "arcane-sword": {
     "name": "Arcane Sword",
     "level": 7,
     "school": "Evocation",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "60 feet"
   },
   "arcanists-magic-aura": {
     "name": "Arcanist\u2019s Magic Aura",
     "level": 2,
     "school": "Illusion",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "Touch"
   },
   "astral-projection": {
     "name": "Astral Projection",
     "level": 9,
     "school": "Necromancy",
     "castingTime": "1 hour",
-    "ritual": false
+    "ritual": false,
+    "range": "10 feet"
   },
   "augury": {
     "name": "Augury",
     "level": 2,
     "school": "Divination",
     "castingTime": "1 minute",
-    "ritual": true
+    "ritual": true,
+    "range": "Self"
   },
   "awaken": {
     "name": "Awaken",
     "level": 5,
     "school": "Transmutation",
     "castingTime": "8 hours",
-    "ritual": false
+    "ritual": false,
+    "range": "Touch"
   },
   "bane": {
     "name": "Bane",
     "level": 1,
     "school": "Enchantment",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "30 feet"
   },
   "banishment": {
     "name": "Banishment",
     "level": 4,
     "school": "Abjuration",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "60 feet"
   },
   "barkskin": {
     "name": "Barkskin",
     "level": 2,
     "school": "Transmutation",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "Touch"
   },
   "beacon-of-hope": {
     "name": "Beacon of Hope",
     "level": 3,
     "school": "Abjuration",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "30 feet"
   },
   "bestow-curse": {
     "name": "Bestow Curse",
     "level": 3,
     "school": "Necromancy",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "Touch"
   },
   "black-tentacles": {
     "name": "Black Tentacles",
     "level": 4,
     "school": "Conjuration",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "90 feet"
   },
   "blade-barrier": {
     "name": "Blade Barrier",
     "level": 6,
     "school": "Evocation",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "90 feet"
   },
   "bless": {
     "name": "Bless",
     "level": 1,
     "school": "Enchantment",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "30 feet"
   },
   "blight": {
     "name": "Blight",
     "level": 4,
     "school": "Necromancy",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "30 feet"
   },
   "blindness-deafness": {
     "name": "Blindness/Deafness",
     "level": 2,
     "school": "Necromancy",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "30 feet"
   },
   "blink": {
     "name": "Blink",
     "level": 3,
     "school": "Transmutation",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "Self"
   },
   "blur": {
     "name": "Blur",
     "level": 2,
     "school": "Illusion",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "Self"
   },
   "branding-smite": {
     "name": "Branding Smite",
     "level": 2,
     "school": "Evocation",
     "castingTime": "1 bonus action",
-    "ritual": false
+    "ritual": false,
+    "range": "Self"
   },
   "burning-hands": {
     "name": "Burning Hands",
     "level": 1,
     "school": "Evocation",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "Self (15-foot cone)"
   },
   "call-lightning": {
     "name": "Call Lightning",
     "level": 3,
     "school": "Conjuration",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "120 feet"
   },
   "calm-emotions": {
     "name": "Calm Emotions",
     "level": 2,
     "school": "Enchantment",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "60 feet"
   },
   "chain-lightning": {
     "name": "Chain Lightning",
     "level": 6,
     "school": "Evocation",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "150 feet"
   },
   "charm-person": {
     "name": "Charm Person",
     "level": 1,
     "school": "Enchantment",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "30 feet"
   },
   "chill-touch": {
     "name": "Chill Touch",
     "level": 0,
     "school": "Necromancy",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "120 feet"
   },
   "circle-of-death": {
     "name": "Circle of Death",
     "level": 6,
     "school": "Necromancy",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "150 feet"
   },
   "clairvoyance": {
     "name": "Clairvoyance",
     "level": 3,
     "school": "Divination",
     "castingTime": "10 minutes",
-    "ritual": false
+    "ritual": false,
+    "range": "1 mile"
   },
   "clone": {
     "name": "Clone",
     "level": 8,
     "school": "Necromancy",
     "castingTime": "1 hour",
-    "ritual": false
+    "ritual": false,
+    "range": "Touch"
   },
   "cloudkill": {
     "name": "Cloudkill",
     "level": 5,
     "school": "Conjuration",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "120 feet"
   },
   "color-spray": {
     "name": "Color Spray",
     "level": 1,
     "school": "Illusion",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "Self (15-foot cone)"
   },
   "command": {
     "name": "Command",
     "level": 1,
     "school": "Enchantment",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "60 feet"
   },
   "commune": {
     "name": "Commune",
     "level": 5,
     "school": "Divination",
     "castingTime": "1 minute",
-    "ritual": true
+    "ritual": true,
+    "range": "Self"
   },
   "commune-with-nature": {
     "name": "Commune with Nature",
     "level": 5,
     "school": "Divination",
     "castingTime": "1 minute",
-    "ritual": true
+    "ritual": true,
+    "range": "Self"
   },
   "comprehend-languages": {
     "name": "Comprehend Languages",
     "level": 1,
     "school": "Divination",
     "castingTime": "1 action",
-    "ritual": true
+    "ritual": true,
+    "range": "Self"
   },
   "compulsion": {
     "name": "Compulsion",
     "level": 4,
     "school": "Enchantment",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "30 feet"
   },
   "cone-of-cold": {
     "name": "Cone of Cold",
     "level": 5,
     "school": "Evocation",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "Self (60-foot cone)"
   },
   "confusion": {
     "name": "Confusion",
     "level": 4,
     "school": "Enchantment",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "90 feet"
   },
   "conjure-animals": {
     "name": "Conjure Animals",
     "level": 3,
     "school": "Conjuration",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "60 feet"
   },
   "conjure-celestial": {
     "name": "Conjure Celestial",
     "level": 7,
     "school": "Conjuration",
     "castingTime": "1 minute",
-    "ritual": false
+    "ritual": false,
+    "range": "90 feet"
   },
   "conjure-elemental": {
     "name": "Conjure Elemental",
     "level": 5,
     "school": "Conjuration",
     "castingTime": "1 minute",
-    "ritual": false
+    "ritual": false,
+    "range": "90 feet"
   },
   "conjure-fey": {
     "name": "Conjure Fey",
     "level": 6,
     "school": "Conjuration",
     "castingTime": "1 minute",
-    "ritual": false
+    "ritual": false,
+    "range": "90 feet"
   },
   "conjure-minor-elementals": {
     "name": "Conjure Minor Elementals",
     "level": 4,
     "school": "Conjuration",
     "castingTime": "1 minute",
-    "ritual": false
+    "ritual": false,
+    "range": "90 feet"
   },
   "conjure-woodland-beings": {
     "name": "Conjure Woodland Beings",
     "level": 4,
     "school": "Conjuration",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "60 feet"
   },
   "contact-other-plane": {
     "name": "Contact Other Plane",
     "level": 5,
     "school": "Divination",
     "castingTime": "1 minute",
-    "ritual": true
+    "ritual": true,
+    "range": "Self"
   },
   "contagion": {
     "name": "Contagion",
     "level": 5,
     "school": "Necromancy",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "Touch"
   },
   "contingency": {
     "name": "Contingency",
     "level": 6,
     "school": "Evocation",
     "castingTime": "10 minutes",
-    "ritual": false
+    "ritual": false,
+    "range": "Self"
   },
   "continual-flame": {
     "name": "Continual Flame",
     "level": 2,
     "school": "Evocation",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "Touch"
   },
   "control-water": {
     "name": "Control Water",
     "level": 4,
     "school": "Transmutation",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "300 feet"
   },
   "control-weather": {
     "name": "Control Weather",
     "level": 8,
     "school": "Transmutation",
     "castingTime": "10 minutes",
-    "ritual": false
+    "ritual": false,
+    "range": "Self (5-mile radius)"
   },
   "counterspell": {
     "name": "Counterspell",
     "level": 3,
     "school": "Abjuration",
     "castingTime": "1 reaction, which you take when you see a creature within 60 feet of you casting a spell",
-    "ritual": false
+    "ritual": false,
+    "range": "60 feet"
   },
   "create-food-and-water": {
     "name": "Create Food and Water",
     "level": 3,
     "school": "Conjuration",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "30 feet"
   },
   "create-or-destroy-water": {
     "name": "Create or Destroy Water",
     "level": 1,
     "school": "Transmutation",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "30 feet"
   },
   "create-undead": {
     "name": "Create Undead",
     "level": 6,
     "school": "Necromancy",
     "castingTime": "1 minute",
-    "ritual": false
+    "ritual": false,
+    "range": "10 feet"
   },
   "creation": {
     "name": "Creation",
     "level": 5,
     "school": "Illusion",
     "castingTime": "1 minute",
-    "ritual": false
+    "ritual": false,
+    "range": "30 feet"
   },
   "cure-wounds": {
     "name": "Cure Wounds",
     "level": 1,
     "school": "Evocation",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "Touch"
   },
   "dancing-lights": {
     "name": "Dancing Lights",
     "level": 0,
     "school": "Evocation",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "120 feet"
   },
   "darkness": {
     "name": "Darkness",
     "level": 2,
     "school": "Evocation",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "60 feet"
   },
   "darkvision": {
     "name": "Darkvision",
     "level": 2,
     "school": "Transmutation",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "Touch"
   },
   "daylight": {
     "name": "Daylight",
     "level": 3,
     "school": "Evocation",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "60 feet"
   },
   "death-ward": {
     "name": "Death Ward",
     "level": 4,
     "school": "Abjuration",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "Touch"
   },
   "delayed-blast-fireball": {
     "name": "Delayed Blast Fireball",
     "level": 7,
     "school": "Evocation",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "150 feet"
   },
   "demiplane": {
     "name": "Demiplane",
     "level": 8,
     "school": "Conjuration",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "60 feet"
   },
   "detect-evil-and-good": {
     "name": "Detect Evil and Good",
     "level": 1,
     "school": "Divination",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "Self"
   },
   "detect-magic": {
     "name": "Detect Magic",
     "level": 1,
     "school": "Divination",
     "castingTime": "1 action",
-    "ritual": true
+    "ritual": true,
+    "range": "Self"
   },
   "detect-poison-and-disease": {
     "name": "Detect Poison and Disease",
     "level": 1,
     "school": "Divination",
     "castingTime": "1 action",
-    "ritual": true
+    "ritual": true,
+    "range": "Self"
   },
   "detect-thoughts": {
     "name": "Detect Thoughts",
     "level": 2,
     "school": "Divination",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "Self"
   },
   "dimension-door": {
     "name": "Dimension Door",
     "level": 4,
     "school": "Conjuration",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "500 feet"
   },
   "disguise-self": {
     "name": "Disguise Self",
     "level": 1,
     "school": "Illusion",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "Self"
   },
   "disintegrate": {
     "name": "Disintegrate",
     "level": 6,
     "school": "Transmutation",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "60 feet"
   },
   "dispel-evil-and-good": {
     "name": "Dispel Evil and Good",
     "level": 5,
     "school": "Abjuration",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "Self"
   },
   "dispel-magic": {
     "name": "Dispel Magic",
     "level": 3,
     "school": "Abjuration",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "120 feet"
   },
   "divination": {
     "name": "Divination",
     "level": 4,
     "school": "Divination",
     "castingTime": "1 action",
-    "ritual": true
+    "ritual": true,
+    "range": "Self"
   },
   "divine-favor": {
     "name": "Divine Favor",
     "level": 1,
     "school": "Evocation",
     "castingTime": "1 bonus action",
-    "ritual": false
+    "ritual": false,
+    "range": "Self"
   },
   "divine-word": {
     "name": "Divine Word",
     "level": 7,
     "school": "Evocation",
     "castingTime": "1 bonus action",
-    "ritual": false
+    "ritual": false,
+    "range": "30 feet"
   },
   "dominate-beast": {
     "name": "Dominate Beast",
     "level": 4,
     "school": "Enchantment",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "60 feet"
   },
   "dominate-monster": {
     "name": "Dominate Monster",
     "level": 8,
     "school": "Enchantment",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "60 feet"
   },
   "dominate-person": {
     "name": "Dominate Person",
     "level": 5,
     "school": "Enchantment",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "60 feet"
   },
   "dream": {
     "name": "Dream",
     "level": 5,
     "school": "Illusion",
     "castingTime": "1 minute",
-    "ritual": false
+    "ritual": false,
+    "range": "Special"
   },
   "druidcraft": {
     "name": "Druidcraft",
     "level": 0,
     "school": "Transmutation",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "30 feet"
   },
   "earthquake": {
     "name": "Earthquake",
     "level": 8,
     "school": "Evocation",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "500 feet"
   },
   "eldritch-blast": {
     "name": "Eldritch Blast",
     "level": 0,
     "school": "Evocation",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "120 feet"
   },
   "enhance-ability": {
     "name": "Enhance Ability",
     "level": 2,
     "school": "Transmutation",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "Touch"
   },
   "enlarge-reduce": {
     "name": "Enlarge/Reduce",
     "level": 2,
     "school": "Transmutation",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "30 feet"
   },
   "entangle": {
     "name": "Entangle",
     "level": 1,
     "school": "Conjuration",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "90 feet"
   },
   "enthrall": {
     "name": "Enthrall",
     "level": 2,
     "school": "Enchantment",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "60 feet"
   },
   "etherealness": {
     "name": "Etherealness",
     "level": 7,
     "school": "Transmutation",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "Self"
   },
   "expeditious-retreat": {
     "name": "Expeditious Retreat",
     "level": 1,
     "school": "Transmutation",
     "castingTime": "1 bonus action",
-    "ritual": false
+    "ritual": false,
+    "range": "Self"
   },
   "eyebite": {
     "name": "Eyebite",
     "level": 6,
     "school": "Necromancy",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "Self"
   },
   "fabricate": {
     "name": "Fabricate",
     "level": 4,
     "school": "Transmutation",
     "castingTime": "10 minutes",
-    "ritual": false
+    "ritual": false,
+    "range": "120 feet"
   },
   "faerie-fire": {
     "name": "Faerie Fire",
     "level": 1,
     "school": "Evocation",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "60 feet"
   },
   "faithful-hound": {
     "name": "Faithful Hound",
     "level": 4,
     "school": "Conjuration",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "30 feet"
   },
   "false-life": {
     "name": "False Life",
     "level": 1,
     "school": "Necromancy",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "Self"
   },
   "fear": {
     "name": "Fear",
     "level": 3,
     "school": "Illusion",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "Self (30-foot cone)"
   },
   "feather-fall": {
     "name": "Feather Fall",
     "level": 1,
     "school": "Transmutation",
     "castingTime": "1 reaction, which you take when you or a creature within 60 feet of you falls",
-    "ritual": false
+    "ritual": false,
+    "range": "60 feet"
   },
   "feeblemind": {
     "name": "Feeblemind",
     "level": 8,
     "school": "Enchantment",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "150 feet"
   },
   "find-familiar": {
     "name": "Find Familiar",
     "level": 1,
     "school": "Conjuration",
     "castingTime": "1 hour",
-    "ritual": true
+    "ritual": true,
+    "range": "10 feet"
   },
   "find-steed": {
     "name": "Find Steed",
     "level": 2,
     "school": "Conjuration",
     "castingTime": "10 minutes",
-    "ritual": false
+    "ritual": false,
+    "range": "30 feet"
   },
   "find-the-path": {
     "name": "Find the Path",
     "level": 6,
     "school": "Divination",
     "castingTime": "1 minute",
-    "ritual": false
+    "ritual": false,
+    "range": "Self"
   },
   "find-traps": {
     "name": "Find Traps",
     "level": 2,
     "school": "Divination",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "120 feet"
   },
   "finger-of-death": {
     "name": "Finger of Death",
     "level": 7,
     "school": "Necromancy",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "60 feet"
   },
   "fireball": {
     "name": "Fireball",
     "level": 3,
     "school": "Evocation",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "150 feet"
   },
   "fire-bolt": {
     "name": "Fire Bolt",
     "level": 0,
     "school": "Evocation",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "120 feet"
   },
   "fire-shield": {
     "name": "Fire Shield",
     "level": 4,
     "school": "Evocation",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "Self"
   },
   "fire-storm": {
     "name": "Fire Storm",
     "level": 7,
     "school": "Evocation",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "150 feet"
   },
   "flame-blade": {
     "name": "Flame Blade",
     "level": 2,
     "school": "Evocation",
     "castingTime": "1 bonus action",
-    "ritual": false
+    "ritual": false,
+    "range": "Self"
   },
   "flame-strike": {
     "name": "Flame Strike",
     "level": 5,
     "school": "Evocation",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "60 feet"
   },
   "flaming-sphere": {
     "name": "Flaming Sphere",
     "level": 2,
     "school": "Conjuration",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "60 feet"
   },
   "flesh-to-stone": {
     "name": "Flesh to Stone",
     "level": 6,
     "school": "Transmutation",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "60 feet"
   },
   "floating-disk": {
     "name": "Floating Disk",
     "level": 1,
     "school": "Conjuration",
     "castingTime": "1 action",
-    "ritual": true
+    "ritual": true,
+    "range": "30 feet"
   },
   "fly": {
     "name": "Fly",
     "level": 3,
     "school": "Transmutation",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "Touch"
   },
   "fog-cloud": {
     "name": "Fog Cloud",
     "level": 1,
     "school": "Conjuration",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "120 feet"
   },
   "forbiddance": {
     "name": "Forbiddance",
     "level": 6,
     "school": "Abjuration",
     "castingTime": "10 minutes",
-    "ritual": true
+    "ritual": true,
+    "range": "Touch"
   },
   "forcecage": {
     "name": "Forcecage",
     "level": 7,
     "school": "Evocation",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "100 feet"
   },
   "foresight": {
     "name": "Foresight",
     "level": 9,
     "school": "Divination",
     "castingTime": "1 minute",
-    "ritual": false
+    "ritual": false,
+    "range": "Touch"
   },
   "freedom-of-movement": {
     "name": "Freedom of Movement",
     "level": 4,
     "school": "Abjuration",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "Touch"
   },
   "freezing-sphere": {
     "name": "Freezing Sphere",
     "level": 6,
     "school": "Evocation",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "300 feet"
   },
   "gaseous-form": {
     "name": "Gaseous Form",
     "level": 3,
     "school": "Transmutation",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "Touch"
   },
   "gate": {
     "name": "Gate",
     "level": 9,
     "school": "Conjuration",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "60 feet"
   },
   "geas": {
     "name": "Geas",
     "level": 5,
     "school": "Enchantment",
     "castingTime": "1 minute",
-    "ritual": false
+    "ritual": false,
+    "range": "60 feet"
   },
   "gentle-repose": {
     "name": "Gentle Repose",
     "level": 2,
     "school": "Necromancy",
     "castingTime": "1 action",
-    "ritual": true
+    "ritual": true,
+    "range": "Touch"
   },
   "giant-insect": {
     "name": "Giant Insect",
     "level": 4,
     "school": "Transmutation",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "30 feet"
   },
   "glibness": {
     "name": "Glibness",
     "level": 8,
     "school": "Transmutation",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "Self"
   },
   "globe-of-invulnerability": {
     "name": "Globe of Invulnerability",
     "level": 6,
     "school": "Abjuration",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "Self (10-foot radius)"
   },
   "glyph-of-warding": {
     "name": "Glyph of Warding",
     "level": 3,
     "school": "Abjuration",
     "castingTime": "1 hour",
-    "ritual": false
+    "ritual": false,
+    "range": "Touch"
   },
   "goodberry": {
     "name": "Goodberry",
     "level": 1,
     "school": "Transmutation",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "Touch"
   },
   "grease": {
     "name": "Grease",
     "level": 1,
     "school": "Conjuration",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "60 feet"
   },
   "greater-invisibility": {
     "name": "Greater Invisibility",
     "level": 4,
     "school": "Illusion",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "Touch"
   },
   "greater-restoration": {
     "name": "Greater Restoration",
     "level": 5,
     "school": "Abjuration",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "Touch"
   },
   "guardian-of-faith": {
     "name": "Guardian of Faith",
     "level": 4,
     "school": "Conjuration",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "30 feet"
   },
   "guards-and-wards": {
     "name": "Guards and Wards",
     "level": 6,
     "school": "Abjuration",
     "castingTime": "10 minutes",
-    "ritual": false
+    "ritual": false,
+    "range": "Touch"
   },
   "guidance": {
     "name": "Guidance",
     "level": 0,
     "school": "Divination",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "Touch"
   },
   "guiding-bolt": {
     "name": "Guiding Bolt",
     "level": 1,
     "school": "Evocation",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "120 feet"
   },
   "gust-of-wind": {
     "name": "Gust of Wind",
     "level": 2,
     "school": "Evocation",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "Self (60-foot line)"
   },
   "hallow": {
     "name": "Hallow",
     "level": 5,
     "school": "Evocation",
     "castingTime": "24 hours",
-    "ritual": false
+    "ritual": false,
+    "range": "Touch"
   },
   "hallucinatory-terrain": {
     "name": "Hallucinatory Terrain",
     "level": 4,
     "school": "Illusion",
     "castingTime": "10 minutes",
-    "ritual": false
+    "ritual": false,
+    "range": "300 feet"
   },
   "harm": {
     "name": "Harm",
     "level": 6,
     "school": "Necromancy",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "60 feet"
   },
   "haste": {
     "name": "Haste",
     "level": 3,
     "school": "Transmutation",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "30 feet"
   },
   "heal": {
     "name": "Heal",
     "level": 6,
     "school": "Evocation",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "60 feet"
   },
   "healing-word": {
     "name": "Healing Word",
     "level": 1,
     "school": "Evocation",
     "castingTime": "1 bonus action",
-    "ritual": false
+    "ritual": false,
+    "range": "60 feet"
   },
   "heat-metal": {
     "name": "Heat Metal",
     "level": 2,
     "school": "Transmutation",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "60 feet"
   },
   "hellish-rebuke": {
     "name": "Hellish Rebuke",
     "level": 1,
     "school": "Evocation",
     "castingTime": "1 reaction, which you take in response to being damaged by a creature within 60 feet of you that you can see",
-    "ritual": false
+    "ritual": false,
+    "range": "60 feet"
   },
   "heroes-feast": {
     "name": "Heroes\u2019 Feast",
     "level": 6,
     "school": "Conjuration",
     "castingTime": "10 minutes",
-    "ritual": false
+    "ritual": false,
+    "range": "30 feet"
   },
   "heroism": {
     "name": "Heroism",
     "level": 1,
     "school": "Enchantment",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "Touch"
   },
   "hideous-laughter": {
     "name": "Hideous Laughter",
     "level": 1,
     "school": "Enchantment",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "30 feet"
   },
   "hold-monster": {
     "name": "Hold Monster",
     "level": 5,
     "school": "Enchantment",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "90 feet"
   },
   "hold-person": {
     "name": "Hold Person",
     "level": 2,
     "school": "Enchantment",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "60 feet"
   },
   "holy-aura": {
     "name": "Holy Aura",
     "level": 8,
     "school": "Abjuration",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "Self"
   },
   "hunters-mark": {
     "name": "Hunter\u2019s Mark",
     "level": 1,
     "school": "Divination",
     "castingTime": "1 bonus action",
-    "ritual": false
+    "ritual": false,
+    "range": "90 feet"
   },
   "hypnotic-pattern": {
     "name": "Hypnotic Pattern",
     "level": 3,
     "school": "Illusion",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "120 feet"
   },
   "ice-storm": {
     "name": "Ice Storm",
     "level": 4,
     "school": "Evocation",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "300 feet"
   },
   "identify": {
     "name": "Identify",
     "level": 1,
     "school": "Divination",
     "castingTime": "1 minute",
-    "ritual": true
+    "ritual": true,
+    "range": "Touch"
   },
   "illusory-script": {
     "name": "Illusory Script",
     "level": 1,
     "school": "Illusion",
     "castingTime": "1 minute",
-    "ritual": true
+    "ritual": true,
+    "range": "Touch"
   },
   "imprisonment": {
     "name": "Imprisonment",
     "level": 9,
     "school": "Abjuration",
     "castingTime": "1 minute",
-    "ritual": false
+    "ritual": false,
+    "range": "30 feet"
   },
   "incendiary-cloud": {
     "name": "Incendiary Cloud",
     "level": 8,
     "school": "Conjuration",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "150 feet"
   },
   "inflict-wounds": {
     "name": "Inflict Wounds",
     "level": 1,
     "school": "Necromancy",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "Touch"
   },
   "insect-plague": {
     "name": "Insect Plague",
     "level": 5,
     "school": "Conjuration",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "300 feet"
   },
   "instant-summons": {
     "name": "Instant Summons",
     "level": 6,
     "school": "Conjuration",
     "castingTime": "1 minute",
-    "ritual": true
+    "ritual": true,
+    "range": "Touch"
   },
   "invisibility": {
     "name": "Invisibility",
     "level": 2,
     "school": "Illusion",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "Touch"
   },
   "irresistible-dance": {
     "name": "Irresistible Dance",
     "level": 6,
     "school": "Enchantment",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "30 feet"
   },
   "jump": {
     "name": "Jump",
     "level": 1,
     "school": "Transmutation",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "Touch"
   },
   "knock": {
     "name": "Knock",
     "level": 2,
     "school": "Transmutation",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "60 feet"
   },
   "legend-lore": {
     "name": "Legend Lore",
     "level": 5,
     "school": "Divination",
     "castingTime": "10 minutes",
-    "ritual": false
+    "ritual": false,
+    "range": "Self"
   },
   "lesser-restoration": {
     "name": "Lesser Restoration",
     "level": 2,
     "school": "Abjuration",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "Touch"
   },
   "levitate": {
     "name": "Levitate",
     "level": 2,
     "school": "Transmutation",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "60 feet"
   },
   "light": {
     "name": "Light",
     "level": 0,
     "school": "Evocation",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "Touch"
   },
   "lightning-bolt": {
     "name": "Lightning Bolt",
     "level": 3,
     "school": "Evocation",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "Self (100-foot line)"
   },
   "locate-animals-or-plants": {
     "name": "Locate Animals or Plants",
     "level": 2,
     "school": "Divination",
     "castingTime": "1 action",
-    "ritual": true
+    "ritual": true,
+    "range": "Self"
   },
   "locate-creature": {
     "name": "Locate Creature",
     "level": 4,
     "school": "Divination",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "Self"
   },
   "locate-object": {
     "name": "Locate Object",
     "level": 2,
     "school": "Divination",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "Self"
   },
   "longstrider": {
     "name": "Longstrider",
     "level": 1,
     "school": "Transmutation",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "Touch"
   },
   "mage-armor": {
     "name": "Mage Armor",
     "level": 1,
     "school": "Abjuration",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "Touch"
   },
   "mage-hand": {
     "name": "Mage Hand",
     "level": 0,
     "school": "Conjuration",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "30 feet"
   },
   "magic-circle": {
     "name": "Magic Circle",
     "level": 3,
     "school": "Abjuration",
     "castingTime": "1 minute",
-    "ritual": false
+    "ritual": false,
+    "range": "10 feet"
   },
   "magic-jar": {
     "name": "Magic Jar",
     "level": 6,
     "school": "Necromancy",
     "castingTime": "1 minute",
-    "ritual": false
+    "ritual": false,
+    "range": "Self"
   },
   "magic-missile": {
     "name": "Magic Missile",
     "level": 1,
     "school": "Evocation",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "120 feet"
   },
   "magic-mouth": {
     "name": "Magic Mouth",
     "level": 2,
     "school": "Illusion",
     "castingTime": "1 minute",
-    "ritual": true
+    "ritual": true,
+    "range": "30 feet"
   },
   "magic-weapon": {
     "name": "Magic Weapon",
     "level": 2,
     "school": "Transmutation",
     "castingTime": "1 bonus action",
-    "ritual": false
+    "ritual": false,
+    "range": "Touch"
   },
   "magnificent-mansion": {
     "name": "Magnificent Mansion",
     "level": 7,
     "school": "Conjuration",
     "castingTime": "1 minute",
-    "ritual": false
+    "ritual": false,
+    "range": "300 feet"
   },
   "major-image": {
     "name": "Major Image",
     "level": 3,
     "school": "Illusion",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "120 feet"
   },
   "mass-cure-wounds": {
     "name": "Mass Cure Wounds",
     "level": 5,
     "school": "Evocation",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "60 feet"
   },
   "mass-heal": {
     "name": "Mass Heal",
     "level": 9,
     "school": "Evocation",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "60 feet"
   },
   "mass-healing-word": {
     "name": "Mass Healing Word",
     "level": 3,
     "school": "Evocation",
     "castingTime": "1 bonus action",
-    "ritual": false
+    "ritual": false,
+    "range": "60 feet"
   },
   "mass-suggestion": {
     "name": "Mass Suggestion",
     "level": 6,
     "school": "Enchantment",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "60 feet"
   },
   "maze": {
     "name": "Maze",
     "level": 8,
     "school": "Conjuration",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "60 feet"
   },
   "meld-into-stone": {
     "name": "Meld into Stone",
     "level": 3,
     "school": "Transmutation",
     "castingTime": "1 action",
-    "ritual": true
+    "ritual": true,
+    "range": "Touch"
   },
   "mending": {
     "name": "Mending",
     "level": 0,
     "school": "Transmutation",
     "castingTime": "1 minute",
-    "ritual": false
+    "ritual": false,
+    "range": "Touch"
   },
   "message": {
     "name": "Message",
     "level": 0,
     "school": "Transmutation",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "120 feet"
   },
   "meteor-swarm": {
     "name": "Meteor Swarm",
     "level": 9,
     "school": "Evocation",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "1 mile"
   },
   "mind-blank": {
     "name": "Mind Blank",
     "level": 8,
     "school": "Abjuration",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "Touch"
   },
   "minor-illusion": {
     "name": "Minor Illusion",
     "level": 0,
     "school": "Illusion",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "30 feet"
   },
   "mirage-arcane": {
     "name": "Mirage Arcane",
     "level": 7,
     "school": "Illusion",
     "castingTime": "10 minutes",
-    "ritual": false
+    "ritual": false,
+    "range": "Sight"
   },
   "mirror-image": {
     "name": "Mirror Image",
     "level": 2,
     "school": "Illusion",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "Self"
   },
   "mislead": {
     "name": "Mislead",
     "level": 5,
     "school": "Illusion",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "Self"
   },
   "misty-step": {
     "name": "Misty Step",
     "level": 2,
     "school": "Conjuration",
     "castingTime": "1 bonus action",
-    "ritual": false
+    "ritual": false,
+    "range": "Self"
   },
   "modify-memory": {
     "name": "Modify Memory",
     "level": 5,
     "school": "Enchantment",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "30 feet"
   },
   "moonbeam": {
     "name": "Moonbeam",
     "level": 2,
     "school": "Evocation",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "120 feet"
   },
   "move-earth": {
     "name": "Move Earth",
     "level": 6,
     "school": "Transmutation",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "120 feet"
   },
   "nondetection": {
     "name": "Nondetection",
     "level": 3,
     "school": "Abjuration",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "Touch"
   },
   "pass-without-trace": {
     "name": "Pass without Trace",
     "level": 2,
     "school": "Abjuration",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "Self"
   },
   "passwall": {
     "name": "Passwall",
     "level": 5,
     "school": "Transmutation",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "30 feet"
   },
   "phantasmal-killer": {
     "name": "Phantasmal Killer",
     "level": 4,
     "school": "Illusion",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "120 feet"
   },
   "phantom-steed": {
     "name": "Phantom Steed",
     "level": 3,
     "school": "Illusion",
     "castingTime": "1 minute",
-    "ritual": true
+    "ritual": true,
+    "range": "30 feet"
   },
   "planar-ally": {
     "name": "Planar Ally",
     "level": 6,
     "school": "Conjuration",
     "castingTime": "10 minutes",
-    "ritual": false
+    "ritual": false,
+    "range": "60 feet"
   },
   "planar-binding": {
     "name": "Planar Binding",
     "level": 5,
     "school": "Abjuration",
     "castingTime": "1 hour",
-    "ritual": false
+    "ritual": false,
+    "range": "60 feet"
   },
   "plane-shift": {
     "name": "Plane Shift",
     "level": 7,
     "school": "Conjuration",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "Touch"
   },
   "plant-growth": {
     "name": "Plant Growth",
     "level": 3,
     "school": "Transmutation",
     "castingTime": "1 action or 8 hours",
-    "ritual": false
+    "ritual": false,
+    "range": "150 feet"
   },
   "poison-spray": {
     "name": "Poison Spray",
     "level": 0,
     "school": "Conjuration",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "10 feet"
   },
   "polymorph": {
     "name": "Polymorph",
     "level": 4,
     "school": "Transmutation",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "60 feet"
   },
   "power-word-kill": {
     "name": "Power Word Kill",
     "level": 9,
     "school": "Enchantment",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "60 feet"
   },
   "power-word-stun": {
     "name": "Power Word Stun",
     "level": 8,
     "school": "Enchantment",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "60 feet"
   },
   "prayer-of-healing": {
     "name": "Prayer of Healing",
     "level": 2,
     "school": "Evocation",
     "castingTime": "10 minutes",
-    "ritual": false
+    "ritual": false,
+    "range": "30 feet"
   },
   "prestidigitation": {
     "name": "Prestidigitation",
     "level": 0,
     "school": "Transmutation",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "10 feet"
   },
   "prismatic-spray": {
     "name": "Prismatic Spray",
     "level": 7,
     "school": "Evocation",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "Self (60-foot cone)"
   },
   "prismatic-wall": {
     "name": "Prismatic Wall",
     "level": 9,
     "school": "Abjuration",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "60 feet"
   },
   "private-sanctum": {
     "name": "Private Sanctum",
     "level": 4,
     "school": "Abjuration",
     "castingTime": "10 minutes",
-    "ritual": false
+    "ritual": false,
+    "range": "120 feet"
   },
   "produce-flame": {
     "name": "Produce Flame",
     "level": 0,
     "school": "Conjuration",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "Self"
   },
   "programmed-illusion": {
     "name": "Programmed Illusion",
     "level": 6,
     "school": "Illusion",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "120 feet"
   },
   "project-image": {
     "name": "Project Image",
     "level": 7,
     "school": "Illusion",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "500 miles"
   },
   "protection-from-energy": {
     "name": "Protection from Energy",
     "level": 3,
     "school": "Abjuration",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "Touch"
   },
   "protection-from-evil-and-good": {
     "name": "Protection from Evil and Good",
     "level": 1,
     "school": "Abjuration",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "Touch"
   },
   "protection-from-poison": {
     "name": "Protection from Poison",
     "level": 2,
     "school": "Abjuration",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "Touch"
   },
   "purify-food-and-drink": {
     "name": "Purify Food and Drink",
     "level": 1,
     "school": "Transmutation",
     "castingTime": "1 action",
-    "ritual": true
+    "ritual": true,
+    "range": "10 feet"
   },
   "raise-dead": {
     "name": "Raise Dead",
     "level": 5,
     "school": "Necromancy",
     "castingTime": "1 hour",
-    "ritual": false
+    "ritual": false,
+    "range": "Touch"
   },
   "ray-of-enfeeblement": {
     "name": "Ray of Enfeeblement",
     "level": 2,
     "school": "Necromancy",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "60 feet"
   },
   "ray-of-frost": {
     "name": "Ray of Frost",
     "level": 0,
     "school": "Evocation",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "60 feet"
   },
   "regenerate": {
     "name": "Regenerate",
     "level": 7,
     "school": "Transmutation",
     "castingTime": "1 minute",
-    "ritual": false
+    "ritual": false,
+    "range": "Touch"
   },
   "reincarnate": {
     "name": "Reincarnate",
     "level": 5,
     "school": "Transmutation",
     "castingTime": "1 hour",
-    "ritual": false
+    "ritual": false,
+    "range": "Touch"
   },
   "remove-curse": {
     "name": "Remove Curse",
     "level": 3,
     "school": "Abjuration",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "Touch"
   },
   "resilient-sphere": {
     "name": "Resilient Sphere",
     "level": 4,
     "school": "Evocation",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "30 feet"
   },
   "resistance": {
     "name": "Resistance",
     "level": 0,
     "school": "Abjuration",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "Touch"
   },
   "resurrection": {
     "name": "Resurrection",
     "level": 7,
     "school": "Necromancy",
     "castingTime": "1 hour",
-    "ritual": false
+    "ritual": false,
+    "range": "Touch"
   },
   "reverse-gravity": {
     "name": "Reverse Gravity",
     "level": 7,
     "school": "Transmutation",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "100 feet"
   },
   "revivify": {
     "name": "Revivify",
     "level": 3,
     "school": "Necromancy",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "Touch"
   },
   "rope-trick": {
     "name": "Rope Trick",
     "level": 2,
     "school": "Transmutation",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "Touch"
   },
   "sacred-flame": {
     "name": "Sacred Flame",
     "level": 0,
     "school": "Evocation",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "60 feet"
   },
   "sanctuary": {
     "name": "Sanctuary",
     "level": 1,
     "school": "Abjuration",
     "castingTime": "1 bonus action",
-    "ritual": false
+    "ritual": false,
+    "range": "30 feet"
   },
   "scorching-ray": {
     "name": "Scorching Ray",
     "level": 2,
     "school": "Evocation",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "120 feet"
   },
   "scrying": {
     "name": "Scrying",
     "level": 5,
     "school": "Divination",
     "castingTime": "10 minutes",
-    "ritual": false
+    "ritual": false,
+    "range": "Self"
   },
   "secret-chest": {
     "name": "Secret Chest",
     "level": 4,
     "school": "Conjuration",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "Touch"
   },
   "see-invisibility": {
     "name": "See Invisibility",
     "level": 2,
     "school": "Divination",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "Self"
   },
   "seeming": {
     "name": "Seeming",
     "level": 5,
     "school": "Illusion",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "30 feet"
   },
   "sending": {
     "name": "Sending",
     "level": 3,
     "school": "Evocation",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "Unlimited"
   },
   "sequester": {
     "name": "Sequester",
     "level": 7,
     "school": "Transmutation",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "Touch"
   },
   "shapechange": {
     "name": "Shapechange",
     "level": 9,
     "school": "Transmutation",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "Self"
   },
   "shatter": {
     "name": "Shatter",
     "level": 2,
     "school": "Evocation",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "60 feet"
   },
   "shield": {
     "name": "Shield",
     "level": 1,
     "school": "Abjuration",
     "castingTime": "1 reaction, which you take when you are hit by an attack or targeted by the magic missile spell",
-    "ritual": false
+    "ritual": false,
+    "range": "Self"
   },
   "shield-of-faith": {
     "name": "Shield of Faith",
     "level": 1,
     "school": "Abjuration",
     "castingTime": "1 bonus action",
-    "ritual": false
+    "ritual": false,
+    "range": "60 feet"
   },
   "shillelagh": {
     "name": "Shillelagh",
     "level": 0,
     "school": "Transmutation",
     "castingTime": "1 bonus action",
-    "ritual": false
+    "ritual": false,
+    "range": "Touch"
   },
   "shocking-grasp": {
     "name": "Shocking Grasp",
     "level": 0,
     "school": "Evocation",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "Touch"
   },
   "silence": {
     "name": "Silence",
     "level": 2,
     "school": "Illusion",
     "castingTime": "1 action",
-    "ritual": true
+    "ritual": true,
+    "range": "120 feet"
   },
   "silent-image": {
     "name": "Silent Image",
     "level": 1,
     "school": "Illusion",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "60 feet"
   },
   "simulacrum": {
     "name": "Simulacrum",
     "level": 7,
     "school": "Illusion",
     "castingTime": "12 hours",
-    "ritual": false
+    "ritual": false,
+    "range": "Touch"
   },
   "sleep": {
     "name": "Sleep",
     "level": 1,
     "school": "Enchantment",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "90 feet"
   },
   "sleet-storm": {
     "name": "Sleet Storm",
     "level": 3,
     "school": "Conjuration",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "150 feet"
   },
   "slow": {
     "name": "Slow",
     "level": 3,
     "school": "Transmutation",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "120 feet"
   },
   "spare-the-dying": {
     "name": "Spare the Dying",
     "level": 0,
     "school": "Necromancy",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "Touch"
   },
   "speak-with-animals": {
     "name": "Speak with Animals",
     "level": 1,
     "school": "Divination",
     "castingTime": "1 action",
-    "ritual": true
+    "ritual": true,
+    "range": "Self"
   },
   "speak-with-dead": {
     "name": "Speak with Dead",
     "level": 3,
     "school": "Necromancy",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "10 feet"
   },
   "speak-with-plants": {
     "name": "Speak with Plants",
     "level": 3,
     "school": "Transmutation",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "Self (30-foot radius)"
   },
   "spider-climb": {
     "name": "Spider Climb",
     "level": 2,
     "school": "Transmutation",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "Touch"
   },
   "spike-growth": {
     "name": "Spike Growth",
     "level": 2,
     "school": "Transmutation",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "150 feet"
   },
   "spirit-guardians": {
     "name": "Spirit Guardians",
     "level": 3,
     "school": "Conjuration",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "Self (15-foot radius)"
   },
   "spiritual-weapon": {
     "name": "Spiritual Weapon",
     "level": 2,
     "school": "Evocation",
     "castingTime": "1 bonus action",
-    "ritual": false
+    "ritual": false,
+    "range": "60 feet"
   },
   "stinking-cloud": {
     "name": "Stinking Cloud",
     "level": 3,
     "school": "Conjuration",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "90 feet"
   },
   "stone-shape": {
     "name": "Stone Shape",
     "level": 4,
     "school": "Transmutation",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "Touch"
   },
   "stoneskin": {
     "name": "Stoneskin",
     "level": 4,
     "school": "Abjuration",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "Touch"
   },
   "storm-of-vengeance": {
     "name": "Storm of Vengeance",
     "level": 9,
     "school": "Conjuration",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "Sight"
   },
   "suggestion": {
     "name": "Suggestion",
     "level": 2,
     "school": "Enchantment",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "30 feet"
   },
   "sunbeam": {
     "name": "Sunbeam",
     "level": 6,
     "school": "Evocation",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "Self (60-foot line)"
   },
   "sunburst": {
     "name": "Sunburst",
     "level": 8,
     "school": "Evocation",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "150 feet"
   },
   "symbol": {
     "name": "Symbol",
     "level": 7,
     "school": "Abjuration",
     "castingTime": "1 minute",
-    "ritual": false
+    "ritual": false,
+    "range": "Touch"
   },
   "telekinesis": {
     "name": "Telekinesis",
     "level": 5,
     "school": "Transmutation",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "60 feet"
   },
   "telepathic-bond": {
     "name": "Telepathic Bond",
     "level": 5,
     "school": "Divination",
     "castingTime": "1 action",
-    "ritual": true
+    "ritual": true,
+    "range": "30 feet"
   },
   "teleport": {
     "name": "Teleport",
     "level": 7,
     "school": "Conjuration",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "10 feet"
   },
   "teleportation-circle": {
     "name": "Teleportation Circle",
     "level": 5,
     "school": "Conjuration",
     "castingTime": "1 minute",
-    "ritual": false
+    "ritual": false,
+    "range": "10 feet"
   },
   "thaumaturgy": {
     "name": "Thaumaturgy",
     "level": 0,
     "school": "Transmutation",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "30 feet"
   },
   "thunderwave": {
     "name": "Thunderwave",
     "level": 1,
     "school": "Evocation",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "Self (15-foot cube)"
   },
   "time-stop": {
     "name": "Time Stop",
     "level": 9,
     "school": "Transmutation",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "Self"
   },
   "tiny-hut": {
     "name": "Tiny Hut",
     "level": 3,
     "school": "Evocation",
     "castingTime": "1 minute",
-    "ritual": true
+    "ritual": true,
+    "range": "Self (10-foot-radius hemisphere)"
   },
   "tongues": {
     "name": "Tongues",
     "level": 3,
     "school": "Divination",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "Touch"
   },
   "transport-via-plants": {
     "name": "Transport via Plants",
     "level": 6,
     "school": "Conjuration",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "10 feet"
   },
   "tree-stride": {
     "name": "Tree Stride",
     "level": 5,
     "school": "Conjuration",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "Self"
   },
   "true-polymorph": {
     "name": "True Polymorph",
     "level": 9,
     "school": "Transmutation",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "30 feet"
   },
   "true-resurrection": {
     "name": "True Resurrection",
     "level": 9,
     "school": "Necromancy",
     "castingTime": "1 hour",
-    "ritual": false
+    "ritual": false,
+    "range": "Touch"
   },
   "true-seeing": {
     "name": "True Seeing",
     "level": 6,
     "school": "Divination",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "Touch"
   },
   "true-strike": {
     "name": "True Strike",
     "level": 0,
     "school": "Divination",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "30 feet"
   },
   "unseen-servant": {
     "name": "Unseen Servant",
     "level": 1,
     "school": "Conjuration",
     "castingTime": "1 action",
-    "ritual": true
+    "ritual": true,
+    "range": "60 feet"
   },
   "vampiric-touch": {
     "name": "Vampiric Touch",
     "level": 3,
     "school": "Necromancy",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "Self"
   },
   "vicious-mockery": {
     "name": "Vicious Mockery",
     "level": 0,
     "school": "Enchantment",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "60 feet"
   },
   "wall-of-fire": {
     "name": "Wall of Fire",
     "level": 4,
     "school": "Evocation",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "120 feet"
   },
   "wall-of-force": {
     "name": "Wall of Force",
     "level": 5,
     "school": "Evocation",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "120 feet"
   },
   "wall-of-ice": {
     "name": "Wall of Ice",
     "level": 6,
     "school": "Evocation",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "120 feet"
   },
   "wall-of-stone": {
     "name": "Wall of Stone",
     "level": 5,
     "school": "Evocation",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "120 feet"
   },
   "wall-of-thorns": {
     "name": "Wall of Thorns",
     "level": 6,
     "school": "Conjuration",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "120 feet"
   },
   "warding-bond": {
     "name": "Warding Bond",
     "level": 2,
     "school": "Abjuration",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "Touch"
   },
   "water-breathing": {
     "name": "Water Breathing",
     "level": 3,
     "school": "Transmutation",
     "castingTime": "1 action",
-    "ritual": true
+    "ritual": true,
+    "range": "30 feet"
   },
   "water-walk": {
     "name": "Water Walk",
     "level": 3,
     "school": "Transmutation",
     "castingTime": "1 action",
-    "ritual": true
+    "ritual": true,
+    "range": "30 feet"
   },
   "web": {
     "name": "Web",
     "level": 2,
     "school": "Conjuration",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "60 feet"
   },
   "weird": {
     "name": "Weird",
     "level": 9,
     "school": "Illusion",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "120 feet"
   },
   "wind-walk": {
     "name": "Wind Walk",
     "level": 6,
     "school": "Transmutation",
     "castingTime": "1 minute",
-    "ritual": false
+    "ritual": false,
+    "range": "30 feet"
   },
   "wind-wall": {
     "name": "Wind Wall",
     "level": 3,
     "school": "Evocation",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "120 feet"
   },
   "wish": {
     "name": "Wish",
     "level": 9,
     "school": "Conjuration",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "Self"
   },
   "word-of-recall": {
     "name": "Word of Recall",
     "level": 6,
     "school": "Conjuration",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "5 feet"
   },
   "zone-of-truth": {
     "name": "Zone of Truth",
     "level": 2,
     "school": "Enchantment",
     "castingTime": "1 action",
-    "ritual": false
+    "ritual": false,
+    "range": "60 feet"
   }
 }

--- a/spells/spells.json
+++ b/spells/spells.json
@@ -1,1916 +1,2235 @@
 {
   "acid-arrow": {
     "name": "Acid Arrow",
-    "ritual": false,
     "level": 2,
-    "school": "Evocation"
+    "school": "Evocation",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "acid-splash": {
     "name": "Acid Splash",
-    "ritual": false,
     "level": 0,
-    "school": "Conjuration"
+    "school": "Conjuration",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "aid": {
     "name": "Aid",
-    "ritual": false,
     "level": 2,
-    "school": "Abjuration"
+    "school": "Abjuration",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "alarm": {
     "name": "Alarm",
-    "ritual": true,
     "level": 1,
-    "school": "Abjuration"
+    "school": "Abjuration",
+    "castingTime": "1 minute",
+    "ritual": true
   },
   "alter-self": {
     "name": "Alter Self",
-    "ritual": false,
     "level": 2,
-    "school": "Transmutation"
+    "school": "Transmutation",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "animal-friendship": {
     "name": "Animal Friendship",
-    "ritual": false,
     "level": 1,
-    "school": "Enchantment"
+    "school": "Enchantment",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "animal-messenger": {
     "name": "Animal Messenger",
-    "ritual": true,
     "level": 2,
-    "school": "Enchantment"
+    "school": "Enchantment",
+    "castingTime": "1 action",
+    "ritual": true
   },
   "animal-shapes": {
     "name": "Animal Shapes",
-    "ritual": false,
     "level": 8,
-    "school": "Transmutation"
+    "school": "Transmutation",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "animate-dead": {
     "name": "Animate Dead",
-    "ritual": false,
     "level": 3,
-    "school": "Necromancy"
+    "school": "Necromancy",
+    "castingTime": "1 minute",
+    "ritual": false
   },
   "animate-objects": {
     "name": "Animate Objects",
-    "ritual": false,
     "level": 5,
-    "school": "Transmutation"
+    "school": "Transmutation",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "antilife-shell": {
     "name": "Antilife Shell",
-    "ritual": false,
     "level": 5,
-    "school": "Abjuration"
+    "school": "Abjuration",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "antimagic-field": {
     "name": "Antimagic Field",
-    "ritual": false,
     "level": 8,
-    "school": "Abjuration"
+    "school": "Abjuration",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "antipathy-sympathy": {
     "name": "Antipathy/Sympathy",
-    "ritual": false,
     "level": 8,
-    "school": "Enchantment"
+    "school": "Enchantment",
+    "castingTime": "1 hour",
+    "ritual": false
   },
   "arcane-eye": {
     "name": "Arcane Eye",
-    "ritual": false,
     "level": 4,
-    "school": "Divination"
+    "school": "Divination",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "arcane-hand": {
     "name": "Arcane Hand",
-    "ritual": false,
     "level": 5,
-    "school": "Evocation"
+    "school": "Evocation",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "arcane-lock": {
     "name": "Arcane Lock",
-    "ritual": false,
     "level": 2,
-    "school": "Abjuration"
+    "school": "Abjuration",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "arcane-sword": {
     "name": "Arcane Sword",
-    "ritual": false,
     "level": 7,
-    "school": "Evocation"
+    "school": "Evocation",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "arcanists-magic-aura": {
     "name": "Arcanist\u2019s Magic Aura",
-    "ritual": false,
     "level": 2,
-    "school": "Illusion"
+    "school": "Illusion",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "astral-projection": {
     "name": "Astral Projection",
-    "ritual": false,
     "level": 9,
-    "school": "Necromancy"
+    "school": "Necromancy",
+    "castingTime": "1 hour",
+    "ritual": false
   },
   "augury": {
     "name": "Augury",
-    "ritual": true,
     "level": 2,
-    "school": "Divination"
+    "school": "Divination",
+    "castingTime": "1 minute",
+    "ritual": true
   },
   "awaken": {
     "name": "Awaken",
-    "ritual": false,
     "level": 5,
-    "school": "Transmutation"
+    "school": "Transmutation",
+    "castingTime": "8 hours",
+    "ritual": false
   },
   "bane": {
     "name": "Bane",
-    "ritual": false,
     "level": 1,
-    "school": "Enchantment"
+    "school": "Enchantment",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "banishment": {
     "name": "Banishment",
-    "ritual": false,
     "level": 4,
-    "school": "Abjuration"
+    "school": "Abjuration",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "barkskin": {
     "name": "Barkskin",
-    "ritual": false,
     "level": 2,
-    "school": "Transmutation"
+    "school": "Transmutation",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "beacon-of-hope": {
     "name": "Beacon of Hope",
-    "ritual": false,
     "level": 3,
-    "school": "Abjuration"
+    "school": "Abjuration",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "bestow-curse": {
     "name": "Bestow Curse",
-    "ritual": false,
     "level": 3,
-    "school": "Necromancy"
+    "school": "Necromancy",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "black-tentacles": {
     "name": "Black Tentacles",
-    "ritual": false,
     "level": 4,
-    "school": "Conjuration"
+    "school": "Conjuration",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "blade-barrier": {
     "name": "Blade Barrier",
-    "ritual": false,
     "level": 6,
-    "school": "Evocation"
+    "school": "Evocation",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "bless": {
     "name": "Bless",
-    "ritual": false,
     "level": 1,
-    "school": "Enchantment"
+    "school": "Enchantment",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "blight": {
     "name": "Blight",
-    "ritual": false,
     "level": 4,
-    "school": "Necromancy"
+    "school": "Necromancy",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "blindness-deafness": {
     "name": "Blindness/Deafness",
-    "ritual": false,
     "level": 2,
-    "school": "Necromancy"
+    "school": "Necromancy",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "blink": {
     "name": "Blink",
-    "ritual": false,
     "level": 3,
-    "school": "Transmutation"
+    "school": "Transmutation",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "blur": {
     "name": "Blur",
-    "ritual": false,
     "level": 2,
-    "school": "Illusion"
+    "school": "Illusion",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "branding-smite": {
     "name": "Branding Smite",
-    "ritual": false,
     "level": 2,
-    "school": "Evocation"
+    "school": "Evocation",
+    "castingTime": "1 bonus action",
+    "ritual": false
   },
   "burning-hands": {
     "name": "Burning Hands",
-    "ritual": false,
     "level": 1,
-    "school": "Evocation"
+    "school": "Evocation",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "call-lightning": {
     "name": "Call Lightning",
-    "ritual": false,
     "level": 3,
-    "school": "Conjuration"
+    "school": "Conjuration",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "calm-emotions": {
     "name": "Calm Emotions",
-    "ritual": false,
     "level": 2,
-    "school": "Enchantment"
+    "school": "Enchantment",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "chain-lightning": {
     "name": "Chain Lightning",
-    "ritual": false,
     "level": 6,
-    "school": "Evocation"
+    "school": "Evocation",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "charm-person": {
     "name": "Charm Person",
-    "ritual": false,
     "level": 1,
-    "school": "Enchantment"
+    "school": "Enchantment",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "chill-touch": {
     "name": "Chill Touch",
-    "ritual": false,
     "level": 0,
-    "school": "Necromancy"
+    "school": "Necromancy",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "circle-of-death": {
     "name": "Circle of Death",
-    "ritual": false,
     "level": 6,
-    "school": "Necromancy"
+    "school": "Necromancy",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "clairvoyance": {
     "name": "Clairvoyance",
-    "ritual": false,
     "level": 3,
-    "school": "Divination"
+    "school": "Divination",
+    "castingTime": "10 minutes",
+    "ritual": false
   },
   "clone": {
     "name": "Clone",
-    "ritual": false,
     "level": 8,
-    "school": "Necromancy"
+    "school": "Necromancy",
+    "castingTime": "1 hour",
+    "ritual": false
   },
   "cloudkill": {
     "name": "Cloudkill",
-    "ritual": false,
     "level": 5,
-    "school": "Conjuration"
+    "school": "Conjuration",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "color-spray": {
     "name": "Color Spray",
-    "ritual": false,
     "level": 1,
-    "school": "Illusion"
+    "school": "Illusion",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "command": {
     "name": "Command",
-    "ritual": false,
     "level": 1,
-    "school": "Enchantment"
+    "school": "Enchantment",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "commune": {
     "name": "Commune",
-    "ritual": true,
     "level": 5,
-    "school": "Divination"
+    "school": "Divination",
+    "castingTime": "1 minute",
+    "ritual": true
   },
   "commune-with-nature": {
     "name": "Commune with Nature",
-    "ritual": true,
     "level": 5,
-    "school": "Divination"
+    "school": "Divination",
+    "castingTime": "1 minute",
+    "ritual": true
   },
   "comprehend-languages": {
     "name": "Comprehend Languages",
-    "ritual": true,
     "level": 1,
-    "school": "Divination"
+    "school": "Divination",
+    "castingTime": "1 action",
+    "ritual": true
   },
   "compulsion": {
     "name": "Compulsion",
-    "ritual": false,
     "level": 4,
-    "school": "Enchantment"
+    "school": "Enchantment",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "cone-of-cold": {
     "name": "Cone of Cold",
-    "ritual": false,
     "level": 5,
-    "school": "Evocation"
+    "school": "Evocation",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "confusion": {
     "name": "Confusion",
-    "ritual": false,
     "level": 4,
-    "school": "Enchantment"
+    "school": "Enchantment",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "conjure-animals": {
     "name": "Conjure Animals",
-    "ritual": false,
     "level": 3,
-    "school": "Conjuration"
+    "school": "Conjuration",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "conjure-celestial": {
     "name": "Conjure Celestial",
-    "ritual": false,
     "level": 7,
-    "school": "Conjuration"
+    "school": "Conjuration",
+    "castingTime": "1 minute",
+    "ritual": false
   },
   "conjure-elemental": {
     "name": "Conjure Elemental",
-    "ritual": false,
     "level": 5,
-    "school": "Conjuration"
+    "school": "Conjuration",
+    "castingTime": "1 minute",
+    "ritual": false
   },
   "conjure-fey": {
     "name": "Conjure Fey",
-    "ritual": false,
     "level": 6,
-    "school": "Conjuration"
+    "school": "Conjuration",
+    "castingTime": "1 minute",
+    "ritual": false
   },
   "conjure-minor-elementals": {
     "name": "Conjure Minor Elementals",
-    "ritual": false,
     "level": 4,
-    "school": "Conjuration"
+    "school": "Conjuration",
+    "castingTime": "1 minute",
+    "ritual": false
   },
   "conjure-woodland-beings": {
     "name": "Conjure Woodland Beings",
-    "ritual": false,
     "level": 4,
-    "school": "Conjuration"
+    "school": "Conjuration",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "contact-other-plane": {
     "name": "Contact Other Plane",
-    "ritual": true,
     "level": 5,
-    "school": "Divination"
+    "school": "Divination",
+    "castingTime": "1 minute",
+    "ritual": true
   },
   "contagion": {
     "name": "Contagion",
-    "ritual": false,
     "level": 5,
-    "school": "Necromancy"
+    "school": "Necromancy",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "contingency": {
     "name": "Contingency",
-    "ritual": false,
     "level": 6,
-    "school": "Evocation"
+    "school": "Evocation",
+    "castingTime": "10 minutes",
+    "ritual": false
   },
   "continual-flame": {
     "name": "Continual Flame",
-    "ritual": false,
     "level": 2,
-    "school": "Evocation"
+    "school": "Evocation",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "control-water": {
     "name": "Control Water",
-    "ritual": false,
     "level": 4,
-    "school": "Transmutation"
+    "school": "Transmutation",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "control-weather": {
     "name": "Control Weather",
-    "ritual": false,
     "level": 8,
-    "school": "Transmutation"
+    "school": "Transmutation",
+    "castingTime": "10 minutes",
+    "ritual": false
   },
   "counterspell": {
     "name": "Counterspell",
-    "ritual": false,
     "level": 3,
-    "school": "Abjuration"
+    "school": "Abjuration",
+    "castingTime": "1 reaction, which you take when you see a creature within 60 feet of you casting a spell",
+    "ritual": false
   },
   "create-food-and-water": {
     "name": "Create Food and Water",
-    "ritual": false,
     "level": 3,
-    "school": "Conjuration"
+    "school": "Conjuration",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "create-or-destroy-water": {
     "name": "Create or Destroy Water",
-    "ritual": false,
     "level": 1,
-    "school": "Transmutation"
+    "school": "Transmutation",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "create-undead": {
     "name": "Create Undead",
-    "ritual": false,
     "level": 6,
-    "school": "Necromancy"
+    "school": "Necromancy",
+    "castingTime": "1 minute",
+    "ritual": false
   },
   "creation": {
     "name": "Creation",
-    "ritual": false,
     "level": 5,
-    "school": "Illusion"
+    "school": "Illusion",
+    "castingTime": "1 minute",
+    "ritual": false
   },
   "cure-wounds": {
     "name": "Cure Wounds",
-    "ritual": false,
     "level": 1,
-    "school": "Evocation"
+    "school": "Evocation",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "dancing-lights": {
     "name": "Dancing Lights",
-    "ritual": false,
     "level": 0,
-    "school": "Evocation"
+    "school": "Evocation",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "darkness": {
     "name": "Darkness",
-    "ritual": false,
     "level": 2,
-    "school": "Evocation"
+    "school": "Evocation",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "darkvision": {
     "name": "Darkvision",
-    "ritual": false,
     "level": 2,
-    "school": "Transmutation"
+    "school": "Transmutation",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "daylight": {
     "name": "Daylight",
-    "ritual": false,
     "level": 3,
-    "school": "Evocation"
+    "school": "Evocation",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "death-ward": {
     "name": "Death Ward",
-    "ritual": false,
     "level": 4,
-    "school": "Abjuration"
+    "school": "Abjuration",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "delayed-blast-fireball": {
     "name": "Delayed Blast Fireball",
-    "ritual": false,
     "level": 7,
-    "school": "Evocation"
+    "school": "Evocation",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "demiplane": {
     "name": "Demiplane",
-    "ritual": false,
     "level": 8,
-    "school": "Conjuration"
+    "school": "Conjuration",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "detect-evil-and-good": {
     "name": "Detect Evil and Good",
-    "ritual": false,
     "level": 1,
-    "school": "Divination"
+    "school": "Divination",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "detect-magic": {
     "name": "Detect Magic",
-    "ritual": true,
     "level": 1,
-    "school": "Divination"
+    "school": "Divination",
+    "castingTime": "1 action",
+    "ritual": true
   },
   "detect-poison-and-disease": {
     "name": "Detect Poison and Disease",
-    "ritual": true,
     "level": 1,
-    "school": "Divination"
+    "school": "Divination",
+    "castingTime": "1 action",
+    "ritual": true
   },
   "detect-thoughts": {
     "name": "Detect Thoughts",
-    "ritual": false,
     "level": 2,
-    "school": "Divination"
+    "school": "Divination",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "dimension-door": {
     "name": "Dimension Door",
-    "ritual": false,
     "level": 4,
-    "school": "Conjuration"
+    "school": "Conjuration",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "disguise-self": {
     "name": "Disguise Self",
-    "ritual": false,
     "level": 1,
-    "school": "Illusion"
+    "school": "Illusion",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "disintegrate": {
     "name": "Disintegrate",
-    "ritual": false,
     "level": 6,
-    "school": "Transmutation"
+    "school": "Transmutation",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "dispel-evil-and-good": {
     "name": "Dispel Evil and Good",
-    "ritual": false,
     "level": 5,
-    "school": "Abjuration"
+    "school": "Abjuration",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "dispel-magic": {
     "name": "Dispel Magic",
-    "ritual": false,
     "level": 3,
-    "school": "Abjuration"
+    "school": "Abjuration",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "divination": {
     "name": "Divination",
-    "ritual": true,
     "level": 4,
-    "school": "Divination"
+    "school": "Divination",
+    "castingTime": "1 action",
+    "ritual": true
   },
   "divine-favor": {
     "name": "Divine Favor",
-    "ritual": false,
     "level": 1,
-    "school": "Evocation"
+    "school": "Evocation",
+    "castingTime": "1 bonus action",
+    "ritual": false
   },
   "divine-word": {
     "name": "Divine Word",
-    "ritual": false,
     "level": 7,
-    "school": "Evocation"
+    "school": "Evocation",
+    "castingTime": "1 bonus action",
+    "ritual": false
   },
   "dominate-beast": {
     "name": "Dominate Beast",
-    "ritual": false,
     "level": 4,
-    "school": "Enchantment"
+    "school": "Enchantment",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "dominate-monster": {
     "name": "Dominate Monster",
-    "ritual": false,
     "level": 8,
-    "school": "Enchantment"
+    "school": "Enchantment",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "dominate-person": {
     "name": "Dominate Person",
-    "ritual": false,
     "level": 5,
-    "school": "Enchantment"
+    "school": "Enchantment",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "dream": {
     "name": "Dream",
-    "ritual": false,
     "level": 5,
-    "school": "Illusion"
+    "school": "Illusion",
+    "castingTime": "1 minute",
+    "ritual": false
   },
   "druidcraft": {
     "name": "Druidcraft",
-    "ritual": false,
     "level": 0,
-    "school": "Transmutation"
+    "school": "Transmutation",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "earthquake": {
     "name": "Earthquake",
-    "ritual": false,
     "level": 8,
-    "school": "Evocation"
+    "school": "Evocation",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "eldritch-blast": {
     "name": "Eldritch Blast",
-    "ritual": false,
     "level": 0,
-    "school": "Evocation"
+    "school": "Evocation",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "enhance-ability": {
     "name": "Enhance Ability",
-    "ritual": false,
     "level": 2,
-    "school": "Transmutation"
+    "school": "Transmutation",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "enlarge-reduce": {
     "name": "Enlarge/Reduce",
-    "ritual": false,
     "level": 2,
-    "school": "Transmutation"
+    "school": "Transmutation",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "entangle": {
     "name": "Entangle",
-    "ritual": false,
     "level": 1,
-    "school": "Conjuration"
+    "school": "Conjuration",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "enthrall": {
     "name": "Enthrall",
-    "ritual": false,
     "level": 2,
-    "school": "Enchantment"
+    "school": "Enchantment",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "etherealness": {
     "name": "Etherealness",
-    "ritual": false,
     "level": 7,
-    "school": "Transmutation"
+    "school": "Transmutation",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "expeditious-retreat": {
     "name": "Expeditious Retreat",
-    "ritual": false,
     "level": 1,
-    "school": "Transmutation"
+    "school": "Transmutation",
+    "castingTime": "1 bonus action",
+    "ritual": false
   },
   "eyebite": {
     "name": "Eyebite",
-    "ritual": false,
     "level": 6,
-    "school": "Necromancy"
+    "school": "Necromancy",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "fabricate": {
     "name": "Fabricate",
-    "ritual": false,
     "level": 4,
-    "school": "Transmutation"
+    "school": "Transmutation",
+    "castingTime": "10 minutes",
+    "ritual": false
   },
   "faerie-fire": {
     "name": "Faerie Fire",
-    "ritual": false,
     "level": 1,
-    "school": "Evocation"
+    "school": "Evocation",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "faithful-hound": {
     "name": "Faithful Hound",
-    "ritual": false,
     "level": 4,
-    "school": "Conjuration"
+    "school": "Conjuration",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "false-life": {
     "name": "False Life",
-    "ritual": false,
     "level": 1,
-    "school": "Necromancy"
+    "school": "Necromancy",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "fear": {
     "name": "Fear",
-    "ritual": false,
     "level": 3,
-    "school": "Illusion"
+    "school": "Illusion",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "feather-fall": {
     "name": "Feather Fall",
-    "ritual": false,
     "level": 1,
-    "school": "Transmutation"
+    "school": "Transmutation",
+    "castingTime": "1 reaction, which you take when you or a creature within 60 feet of you falls",
+    "ritual": false
   },
   "feeblemind": {
     "name": "Feeblemind",
-    "ritual": false,
     "level": 8,
-    "school": "Enchantment"
+    "school": "Enchantment",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "find-familiar": {
     "name": "Find Familiar",
-    "ritual": true,
     "level": 1,
-    "school": "Conjuration"
+    "school": "Conjuration",
+    "castingTime": "1 hour",
+    "ritual": true
   },
   "find-steed": {
     "name": "Find Steed",
-    "ritual": false,
     "level": 2,
-    "school": "Conjuration"
+    "school": "Conjuration",
+    "castingTime": "10 minutes",
+    "ritual": false
   },
   "find-the-path": {
     "name": "Find the Path",
-    "ritual": false,
     "level": 6,
-    "school": "Divination"
+    "school": "Divination",
+    "castingTime": "1 minute",
+    "ritual": false
   },
   "find-traps": {
     "name": "Find Traps",
-    "ritual": false,
     "level": 2,
-    "school": "Divination"
+    "school": "Divination",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "finger-of-death": {
     "name": "Finger of Death",
-    "ritual": false,
     "level": 7,
-    "school": "Necromancy"
+    "school": "Necromancy",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "fireball": {
     "name": "Fireball",
-    "ritual": false,
     "level": 3,
-    "school": "Evocation"
+    "school": "Evocation",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "fire-bolt": {
     "name": "Fire Bolt",
-    "ritual": false,
     "level": 0,
-    "school": "Evocation"
+    "school": "Evocation",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "fire-shield": {
     "name": "Fire Shield",
-    "ritual": false,
     "level": 4,
-    "school": "Evocation"
+    "school": "Evocation",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "fire-storm": {
     "name": "Fire Storm",
-    "ritual": false,
     "level": 7,
-    "school": "Evocation"
+    "school": "Evocation",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "flame-blade": {
     "name": "Flame Blade",
-    "ritual": false,
     "level": 2,
-    "school": "Evocation"
+    "school": "Evocation",
+    "castingTime": "1 bonus action",
+    "ritual": false
   },
   "flame-strike": {
     "name": "Flame Strike",
-    "ritual": false,
     "level": 5,
-    "school": "Evocation"
+    "school": "Evocation",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "flaming-sphere": {
     "name": "Flaming Sphere",
-    "ritual": false,
     "level": 2,
-    "school": "Conjuration"
+    "school": "Conjuration",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "flesh-to-stone": {
     "name": "Flesh to Stone",
-    "ritual": false,
     "level": 6,
-    "school": "Transmutation"
+    "school": "Transmutation",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "floating-disk": {
     "name": "Floating Disk",
-    "ritual": true,
     "level": 1,
-    "school": "Conjuration"
+    "school": "Conjuration",
+    "castingTime": "1 action",
+    "ritual": true
   },
   "fly": {
     "name": "Fly",
-    "ritual": false,
     "level": 3,
-    "school": "Transmutation"
+    "school": "Transmutation",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "fog-cloud": {
     "name": "Fog Cloud",
-    "ritual": false,
     "level": 1,
-    "school": "Conjuration"
+    "school": "Conjuration",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "forbiddance": {
     "name": "Forbiddance",
-    "ritual": true,
     "level": 6,
-    "school": "Abjuration"
+    "school": "Abjuration",
+    "castingTime": "10 minutes",
+    "ritual": true
   },
   "forcecage": {
     "name": "Forcecage",
-    "ritual": false,
     "level": 7,
-    "school": "Evocation"
+    "school": "Evocation",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "foresight": {
     "name": "Foresight",
-    "ritual": false,
     "level": 9,
-    "school": "Divination"
+    "school": "Divination",
+    "castingTime": "1 minute",
+    "ritual": false
   },
   "freedom-of-movement": {
     "name": "Freedom of Movement",
-    "ritual": false,
     "level": 4,
-    "school": "Abjuration"
+    "school": "Abjuration",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "freezing-sphere": {
     "name": "Freezing Sphere",
-    "ritual": false,
     "level": 6,
-    "school": "Evocation"
+    "school": "Evocation",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "gaseous-form": {
     "name": "Gaseous Form",
-    "ritual": false,
     "level": 3,
-    "school": "Transmutation"
+    "school": "Transmutation",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "gate": {
     "name": "Gate",
-    "ritual": false,
     "level": 9,
-    "school": "Conjuration"
+    "school": "Conjuration",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "geas": {
     "name": "Geas",
-    "ritual": false,
     "level": 5,
-    "school": "Enchantment"
+    "school": "Enchantment",
+    "castingTime": "1 minute",
+    "ritual": false
   },
   "gentle-repose": {
     "name": "Gentle Repose",
-    "ritual": true,
     "level": 2,
-    "school": "Necromancy"
+    "school": "Necromancy",
+    "castingTime": "1 action",
+    "ritual": true
   },
   "giant-insect": {
     "name": "Giant Insect",
-    "ritual": false,
     "level": 4,
-    "school": "Transmutation"
+    "school": "Transmutation",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "glibness": {
     "name": "Glibness",
-    "ritual": false,
     "level": 8,
-    "school": "Transmutation"
+    "school": "Transmutation",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "globe-of-invulnerability": {
     "name": "Globe of Invulnerability",
-    "ritual": false,
     "level": 6,
-    "school": "Abjuration"
+    "school": "Abjuration",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "glyph-of-warding": {
     "name": "Glyph of Warding",
-    "ritual": false,
     "level": 3,
-    "school": "Abjuration"
+    "school": "Abjuration",
+    "castingTime": "1 hour",
+    "ritual": false
   },
   "goodberry": {
     "name": "Goodberry",
-    "ritual": false,
     "level": 1,
-    "school": "Transmutation"
+    "school": "Transmutation",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "grease": {
     "name": "Grease",
-    "ritual": false,
     "level": 1,
-    "school": "Conjuration"
+    "school": "Conjuration",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "greater-invisibility": {
     "name": "Greater Invisibility",
-    "ritual": false,
     "level": 4,
-    "school": "Illusion"
+    "school": "Illusion",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "greater-restoration": {
     "name": "Greater Restoration",
-    "ritual": false,
     "level": 5,
-    "school": "Abjuration"
+    "school": "Abjuration",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "guardian-of-faith": {
     "name": "Guardian of Faith",
-    "ritual": false,
     "level": 4,
-    "school": "Conjuration"
+    "school": "Conjuration",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "guards-and-wards": {
     "name": "Guards and Wards",
-    "ritual": false,
     "level": 6,
-    "school": "Abjuration"
+    "school": "Abjuration",
+    "castingTime": "10 minutes",
+    "ritual": false
   },
   "guidance": {
     "name": "Guidance",
-    "ritual": false,
     "level": 0,
-    "school": "Divination"
+    "school": "Divination",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "guiding-bolt": {
     "name": "Guiding Bolt",
-    "ritual": false,
     "level": 1,
-    "school": "Evocation"
+    "school": "Evocation",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "gust-of-wind": {
     "name": "Gust of Wind",
-    "ritual": false,
     "level": 2,
-    "school": "Evocation"
+    "school": "Evocation",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "hallow": {
     "name": "Hallow",
-    "ritual": false,
     "level": 5,
-    "school": "Evocation"
+    "school": "Evocation",
+    "castingTime": "24 hours",
+    "ritual": false
   },
   "hallucinatory-terrain": {
     "name": "Hallucinatory Terrain",
-    "ritual": false,
     "level": 4,
-    "school": "Illusion"
+    "school": "Illusion",
+    "castingTime": "10 minutes",
+    "ritual": false
   },
   "harm": {
     "name": "Harm",
-    "ritual": false,
     "level": 6,
-    "school": "Necromancy"
+    "school": "Necromancy",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "haste": {
     "name": "Haste",
-    "ritual": false,
     "level": 3,
-    "school": "Transmutation"
+    "school": "Transmutation",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "heal": {
     "name": "Heal",
-    "ritual": false,
     "level": 6,
-    "school": "Evocation"
+    "school": "Evocation",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "healing-word": {
     "name": "Healing Word",
-    "ritual": false,
     "level": 1,
-    "school": "Evocation"
+    "school": "Evocation",
+    "castingTime": "1 bonus action",
+    "ritual": false
   },
   "heat-metal": {
     "name": "Heat Metal",
-    "ritual": false,
     "level": 2,
-    "school": "Transmutation"
+    "school": "Transmutation",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "hellish-rebuke": {
     "name": "Hellish Rebuke",
-    "ritual": false,
     "level": 1,
-    "school": "Evocation"
+    "school": "Evocation",
+    "castingTime": "1 reaction, which you take in response to being damaged by a creature within 60 feet of you that you can see",
+    "ritual": false
   },
   "heroes-feast": {
     "name": "Heroes\u2019 Feast",
-    "ritual": false,
     "level": 6,
-    "school": "Conjuration"
+    "school": "Conjuration",
+    "castingTime": "10 minutes",
+    "ritual": false
   },
   "heroism": {
     "name": "Heroism",
-    "ritual": false,
     "level": 1,
-    "school": "Enchantment"
+    "school": "Enchantment",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "hideous-laughter": {
     "name": "Hideous Laughter",
-    "ritual": false,
     "level": 1,
-    "school": "Enchantment"
+    "school": "Enchantment",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "hold-monster": {
     "name": "Hold Monster",
-    "ritual": false,
     "level": 5,
-    "school": "Enchantment"
+    "school": "Enchantment",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "hold-person": {
     "name": "Hold Person",
-    "ritual": false,
     "level": 2,
-    "school": "Enchantment"
+    "school": "Enchantment",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "holy-aura": {
     "name": "Holy Aura",
-    "ritual": false,
     "level": 8,
-    "school": "Abjuration"
+    "school": "Abjuration",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "hunters-mark": {
     "name": "Hunter\u2019s Mark",
-    "ritual": false,
     "level": 1,
-    "school": "Divination"
+    "school": "Divination",
+    "castingTime": "1 bonus action",
+    "ritual": false
   },
   "hypnotic-pattern": {
     "name": "Hypnotic Pattern",
-    "ritual": false,
     "level": 3,
-    "school": "Illusion"
+    "school": "Illusion",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "ice-storm": {
     "name": "Ice Storm",
-    "ritual": false,
     "level": 4,
-    "school": "Evocation"
+    "school": "Evocation",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "identify": {
     "name": "Identify",
-    "ritual": true,
     "level": 1,
-    "school": "Divination"
+    "school": "Divination",
+    "castingTime": "1 minute",
+    "ritual": true
   },
   "illusory-script": {
     "name": "Illusory Script",
-    "ritual": true,
     "level": 1,
-    "school": "Illusion"
+    "school": "Illusion",
+    "castingTime": "1 minute",
+    "ritual": true
   },
   "imprisonment": {
     "name": "Imprisonment",
-    "ritual": false,
     "level": 9,
-    "school": "Abjuration"
+    "school": "Abjuration",
+    "castingTime": "1 minute",
+    "ritual": false
   },
   "incendiary-cloud": {
     "name": "Incendiary Cloud",
-    "ritual": false,
     "level": 8,
-    "school": "Conjuration"
+    "school": "Conjuration",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "inflict-wounds": {
     "name": "Inflict Wounds",
-    "ritual": false,
     "level": 1,
-    "school": "Necromancy"
+    "school": "Necromancy",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "insect-plague": {
     "name": "Insect Plague",
-    "ritual": false,
     "level": 5,
-    "school": "Conjuration"
+    "school": "Conjuration",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "instant-summons": {
     "name": "Instant Summons",
-    "ritual": true,
     "level": 6,
-    "school": "Conjuration"
+    "school": "Conjuration",
+    "castingTime": "1 minute",
+    "ritual": true
   },
   "invisibility": {
     "name": "Invisibility",
-    "ritual": false,
     "level": 2,
-    "school": "Illusion"
+    "school": "Illusion",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "irresistible-dance": {
     "name": "Irresistible Dance",
-    "ritual": false,
     "level": 6,
-    "school": "Enchantment"
+    "school": "Enchantment",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "jump": {
     "name": "Jump",
-    "ritual": false,
     "level": 1,
-    "school": "Transmutation"
+    "school": "Transmutation",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "knock": {
     "name": "Knock",
-    "ritual": false,
     "level": 2,
-    "school": "Transmutation"
+    "school": "Transmutation",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "legend-lore": {
     "name": "Legend Lore",
-    "ritual": false,
     "level": 5,
-    "school": "Divination"
+    "school": "Divination",
+    "castingTime": "10 minutes",
+    "ritual": false
   },
   "lesser-restoration": {
     "name": "Lesser Restoration",
-    "ritual": false,
     "level": 2,
-    "school": "Abjuration"
+    "school": "Abjuration",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "levitate": {
     "name": "Levitate",
-    "ritual": false,
     "level": 2,
-    "school": "Transmutation"
+    "school": "Transmutation",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "light": {
     "name": "Light",
-    "ritual": false,
     "level": 0,
-    "school": "Evocation"
+    "school": "Evocation",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "lightning-bolt": {
     "name": "Lightning Bolt",
-    "ritual": false,
     "level": 3,
-    "school": "Evocation"
+    "school": "Evocation",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "locate-animals-or-plants": {
     "name": "Locate Animals or Plants",
-    "ritual": true,
     "level": 2,
-    "school": "Divination"
+    "school": "Divination",
+    "castingTime": "1 action",
+    "ritual": true
   },
   "locate-creature": {
     "name": "Locate Creature",
-    "ritual": false,
     "level": 4,
-    "school": "Divination"
+    "school": "Divination",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "locate-object": {
     "name": "Locate Object",
-    "ritual": false,
     "level": 2,
-    "school": "Divination"
+    "school": "Divination",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "longstrider": {
     "name": "Longstrider",
-    "ritual": false,
     "level": 1,
-    "school": "Transmutation"
+    "school": "Transmutation",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "mage-armor": {
     "name": "Mage Armor",
-    "ritual": false,
     "level": 1,
-    "school": "Abjuration"
+    "school": "Abjuration",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "mage-hand": {
     "name": "Mage Hand",
-    "ritual": false,
     "level": 0,
-    "school": "Conjuration"
+    "school": "Conjuration",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "magic-circle": {
     "name": "Magic Circle",
-    "ritual": false,
     "level": 3,
-    "school": "Abjuration"
+    "school": "Abjuration",
+    "castingTime": "1 minute",
+    "ritual": false
   },
   "magic-jar": {
     "name": "Magic Jar",
-    "ritual": false,
     "level": 6,
-    "school": "Necromancy"
+    "school": "Necromancy",
+    "castingTime": "1 minute",
+    "ritual": false
   },
   "magic-missile": {
     "name": "Magic Missile",
-    "ritual": false,
     "level": 1,
-    "school": "Evocation"
+    "school": "Evocation",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "magic-mouth": {
     "name": "Magic Mouth",
-    "ritual": true,
     "level": 2,
-    "school": "Illusion"
+    "school": "Illusion",
+    "castingTime": "1 minute",
+    "ritual": true
   },
   "magic-weapon": {
     "name": "Magic Weapon",
-    "ritual": false,
     "level": 2,
-    "school": "Transmutation"
+    "school": "Transmutation",
+    "castingTime": "1 bonus action",
+    "ritual": false
   },
   "magnificent-mansion": {
     "name": "Magnificent Mansion",
-    "ritual": false,
     "level": 7,
-    "school": "Conjuration"
+    "school": "Conjuration",
+    "castingTime": "1 minute",
+    "ritual": false
   },
   "major-image": {
     "name": "Major Image",
-    "ritual": false,
     "level": 3,
-    "school": "Illusion"
+    "school": "Illusion",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "mass-cure-wounds": {
     "name": "Mass Cure Wounds",
-    "ritual": false,
     "level": 5,
-    "school": "Evocation"
+    "school": "Evocation",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "mass-heal": {
     "name": "Mass Heal",
-    "ritual": false,
     "level": 9,
-    "school": "Evocation"
+    "school": "Evocation",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "mass-healing-word": {
     "name": "Mass Healing Word",
-    "ritual": false,
     "level": 3,
-    "school": "Evocation"
+    "school": "Evocation",
+    "castingTime": "1 bonus action",
+    "ritual": false
   },
   "mass-suggestion": {
     "name": "Mass Suggestion",
-    "ritual": false,
     "level": 6,
-    "school": "Enchantment"
+    "school": "Enchantment",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "maze": {
     "name": "Maze",
-    "ritual": false,
     "level": 8,
-    "school": "Conjuration"
+    "school": "Conjuration",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "meld-into-stone": {
     "name": "Meld into Stone",
-    "ritual": true,
     "level": 3,
-    "school": "Transmutation"
+    "school": "Transmutation",
+    "castingTime": "1 action",
+    "ritual": true
   },
   "mending": {
     "name": "Mending",
-    "ritual": false,
     "level": 0,
-    "school": "Transmutation"
+    "school": "Transmutation",
+    "castingTime": "1 minute",
+    "ritual": false
   },
   "message": {
     "name": "Message",
-    "ritual": false,
     "level": 0,
-    "school": "Transmutation"
+    "school": "Transmutation",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "meteor-swarm": {
     "name": "Meteor Swarm",
-    "ritual": false,
     "level": 9,
-    "school": "Evocation"
+    "school": "Evocation",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "mind-blank": {
     "name": "Mind Blank",
-    "ritual": false,
     "level": 8,
-    "school": "Abjuration"
+    "school": "Abjuration",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "minor-illusion": {
     "name": "Minor Illusion",
-    "ritual": false,
     "level": 0,
-    "school": "Illusion"
+    "school": "Illusion",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "mirage-arcane": {
     "name": "Mirage Arcane",
-    "ritual": false,
     "level": 7,
-    "school": "Illusion"
+    "school": "Illusion",
+    "castingTime": "10 minutes",
+    "ritual": false
   },
   "mirror-image": {
     "name": "Mirror Image",
-    "ritual": false,
     "level": 2,
-    "school": "Illusion"
+    "school": "Illusion",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "mislead": {
     "name": "Mislead",
-    "ritual": false,
     "level": 5,
-    "school": "Illusion"
+    "school": "Illusion",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "misty-step": {
     "name": "Misty Step",
-    "ritual": false,
     "level": 2,
-    "school": "Conjuration"
+    "school": "Conjuration",
+    "castingTime": "1 bonus action",
+    "ritual": false
   },
   "modify-memory": {
     "name": "Modify Memory",
-    "ritual": false,
     "level": 5,
-    "school": "Enchantment"
+    "school": "Enchantment",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "moonbeam": {
     "name": "Moonbeam",
-    "ritual": false,
     "level": 2,
-    "school": "Evocation"
+    "school": "Evocation",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "move-earth": {
     "name": "Move Earth",
-    "ritual": false,
     "level": 6,
-    "school": "Transmutation"
+    "school": "Transmutation",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "nondetection": {
     "name": "Nondetection",
-    "ritual": false,
     "level": 3,
-    "school": "Abjuration"
+    "school": "Abjuration",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "pass-without-trace": {
     "name": "Pass without Trace",
-    "ritual": false,
     "level": 2,
-    "school": "Abjuration"
+    "school": "Abjuration",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "passwall": {
     "name": "Passwall",
-    "ritual": false,
     "level": 5,
-    "school": "Transmutation"
+    "school": "Transmutation",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "phantasmal-killer": {
     "name": "Phantasmal Killer",
-    "ritual": false,
     "level": 4,
-    "school": "Illusion"
+    "school": "Illusion",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "phantom-steed": {
     "name": "Phantom Steed",
-    "ritual": true,
     "level": 3,
-    "school": "Illusion"
+    "school": "Illusion",
+    "castingTime": "1 minute",
+    "ritual": true
   },
   "planar-ally": {
     "name": "Planar Ally",
-    "ritual": false,
     "level": 6,
-    "school": "Conjuration"
+    "school": "Conjuration",
+    "castingTime": "10 minutes",
+    "ritual": false
   },
   "planar-binding": {
     "name": "Planar Binding",
-    "ritual": false,
     "level": 5,
-    "school": "Abjuration"
+    "school": "Abjuration",
+    "castingTime": "1 hour",
+    "ritual": false
   },
   "plane-shift": {
     "name": "Plane Shift",
-    "ritual": false,
     "level": 7,
-    "school": "Conjuration"
+    "school": "Conjuration",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "plant-growth": {
     "name": "Plant Growth",
-    "ritual": false,
     "level": 3,
-    "school": "Transmutation"
+    "school": "Transmutation",
+    "castingTime": "1 action or 8 hours",
+    "ritual": false
   },
   "poison-spray": {
     "name": "Poison Spray",
-    "ritual": false,
     "level": 0,
-    "school": "Conjuration"
+    "school": "Conjuration",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "polymorph": {
     "name": "Polymorph",
-    "ritual": false,
     "level": 4,
-    "school": "Transmutation"
+    "school": "Transmutation",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "power-word-kill": {
     "name": "Power Word Kill",
-    "ritual": false,
     "level": 9,
-    "school": "Enchantment"
+    "school": "Enchantment",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "power-word-stun": {
     "name": "Power Word Stun",
-    "ritual": false,
     "level": 8,
-    "school": "Enchantment"
+    "school": "Enchantment",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "prayer-of-healing": {
     "name": "Prayer of Healing",
-    "ritual": false,
     "level": 2,
-    "school": "Evocation"
+    "school": "Evocation",
+    "castingTime": "10 minutes",
+    "ritual": false
   },
   "prestidigitation": {
     "name": "Prestidigitation",
-    "ritual": false,
     "level": 0,
-    "school": "Transmutation"
+    "school": "Transmutation",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "prismatic-spray": {
     "name": "Prismatic Spray",
-    "ritual": false,
     "level": 7,
-    "school": "Evocation"
+    "school": "Evocation",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "prismatic-wall": {
     "name": "Prismatic Wall",
-    "ritual": false,
     "level": 9,
-    "school": "Abjuration"
+    "school": "Abjuration",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "private-sanctum": {
     "name": "Private Sanctum",
-    "ritual": false,
     "level": 4,
-    "school": "Abjuration"
+    "school": "Abjuration",
+    "castingTime": "10 minutes",
+    "ritual": false
   },
   "produce-flame": {
     "name": "Produce Flame",
-    "ritual": false,
     "level": 0,
-    "school": "Conjuration"
+    "school": "Conjuration",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "programmed-illusion": {
     "name": "Programmed Illusion",
-    "ritual": false,
     "level": 6,
-    "school": "Illusion"
+    "school": "Illusion",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "project-image": {
     "name": "Project Image",
-    "ritual": false,
     "level": 7,
-    "school": "Illusion"
+    "school": "Illusion",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "protection-from-energy": {
     "name": "Protection from Energy",
-    "ritual": false,
     "level": 3,
-    "school": "Abjuration"
+    "school": "Abjuration",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "protection-from-evil-and-good": {
     "name": "Protection from Evil and Good",
-    "ritual": false,
     "level": 1,
-    "school": "Abjuration"
+    "school": "Abjuration",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "protection-from-poison": {
     "name": "Protection from Poison",
-    "ritual": false,
     "level": 2,
-    "school": "Abjuration"
+    "school": "Abjuration",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "purify-food-and-drink": {
     "name": "Purify Food and Drink",
-    "ritual": true,
     "level": 1,
-    "school": "Transmutation"
+    "school": "Transmutation",
+    "castingTime": "1 action",
+    "ritual": true
   },
   "raise-dead": {
     "name": "Raise Dead",
-    "ritual": false,
     "level": 5,
-    "school": "Necromancy"
+    "school": "Necromancy",
+    "castingTime": "1 hour",
+    "ritual": false
   },
   "ray-of-enfeeblement": {
     "name": "Ray of Enfeeblement",
-    "ritual": false,
     "level": 2,
-    "school": "Necromancy"
+    "school": "Necromancy",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "ray-of-frost": {
     "name": "Ray of Frost",
-    "ritual": false,
     "level": 0,
-    "school": "Evocation"
+    "school": "Evocation",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "regenerate": {
     "name": "Regenerate",
-    "ritual": false,
     "level": 7,
-    "school": "Transmutation"
+    "school": "Transmutation",
+    "castingTime": "1 minute",
+    "ritual": false
   },
   "reincarnate": {
     "name": "Reincarnate",
-    "ritual": false,
     "level": 5,
-    "school": "Transmutation"
+    "school": "Transmutation",
+    "castingTime": "1 hour",
+    "ritual": false
   },
   "remove-curse": {
     "name": "Remove Curse",
-    "ritual": false,
     "level": 3,
-    "school": "Abjuration"
+    "school": "Abjuration",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "resilient-sphere": {
     "name": "Resilient Sphere",
-    "ritual": false,
     "level": 4,
-    "school": "Evocation"
+    "school": "Evocation",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "resistance": {
     "name": "Resistance",
-    "ritual": false,
     "level": 0,
-    "school": "Abjuration"
+    "school": "Abjuration",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "resurrection": {
     "name": "Resurrection",
-    "ritual": false,
     "level": 7,
-    "school": "Necromancy"
+    "school": "Necromancy",
+    "castingTime": "1 hour",
+    "ritual": false
   },
   "reverse-gravity": {
     "name": "Reverse Gravity",
-    "ritual": false,
     "level": 7,
-    "school": "Transmutation"
+    "school": "Transmutation",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "revivify": {
     "name": "Revivify",
-    "ritual": false,
     "level": 3,
-    "school": "Necromancy"
+    "school": "Necromancy",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "rope-trick": {
     "name": "Rope Trick",
-    "ritual": false,
     "level": 2,
-    "school": "Transmutation"
+    "school": "Transmutation",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "sacred-flame": {
     "name": "Sacred Flame",
-    "ritual": false,
     "level": 0,
-    "school": "Evocation"
+    "school": "Evocation",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "sanctuary": {
     "name": "Sanctuary",
-    "ritual": false,
     "level": 1,
-    "school": "Abjuration"
+    "school": "Abjuration",
+    "castingTime": "1 bonus action",
+    "ritual": false
   },
   "scorching-ray": {
     "name": "Scorching Ray",
-    "ritual": false,
     "level": 2,
-    "school": "Evocation"
+    "school": "Evocation",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "scrying": {
     "name": "Scrying",
-    "ritual": false,
     "level": 5,
-    "school": "Divination"
+    "school": "Divination",
+    "castingTime": "10 minutes",
+    "ritual": false
   },
   "secret-chest": {
     "name": "Secret Chest",
-    "ritual": false,
     "level": 4,
-    "school": "Conjuration"
+    "school": "Conjuration",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "see-invisibility": {
     "name": "See Invisibility",
-    "ritual": false,
     "level": 2,
-    "school": "Divination"
+    "school": "Divination",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "seeming": {
     "name": "Seeming",
-    "ritual": false,
     "level": 5,
-    "school": "Illusion"
+    "school": "Illusion",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "sending": {
     "name": "Sending",
-    "ritual": false,
     "level": 3,
-    "school": "Evocation"
+    "school": "Evocation",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "sequester": {
     "name": "Sequester",
-    "ritual": false,
     "level": 7,
-    "school": "Transmutation"
+    "school": "Transmutation",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "shapechange": {
     "name": "Shapechange",
-    "ritual": false,
     "level": 9,
-    "school": "Transmutation"
+    "school": "Transmutation",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "shatter": {
     "name": "Shatter",
-    "ritual": false,
     "level": 2,
-    "school": "Evocation"
+    "school": "Evocation",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "shield": {
     "name": "Shield",
-    "ritual": false,
     "level": 1,
-    "school": "Abjuration"
+    "school": "Abjuration",
+    "castingTime": "1 reaction, which you take when you are hit by an attack or targeted by the",
+    "ritual": false
   },
   "shield-of-faith": {
     "name": "Shield of Faith",
-    "ritual": false,
     "level": 1,
-    "school": "Abjuration"
+    "school": "Abjuration",
+    "castingTime": "1 bonus action",
+    "ritual": false
   },
   "shillelagh": {
     "name": "Shillelagh",
-    "ritual": false,
     "level": 0,
-    "school": "Transmutation"
+    "school": "Transmutation",
+    "castingTime": "1 bonus action",
+    "ritual": false
   },
   "shocking-grasp": {
     "name": "Shocking Grasp",
-    "ritual": false,
     "level": 0,
-    "school": "Evocation"
+    "school": "Evocation",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "silence": {
     "name": "Silence",
-    "ritual": true,
     "level": 2,
-    "school": "Illusion"
+    "school": "Illusion",
+    "castingTime": "1 action",
+    "ritual": true
   },
   "silent-image": {
     "name": "Silent Image",
-    "ritual": false,
     "level": 1,
-    "school": "Illusion"
+    "school": "Illusion",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "simulacrum": {
     "name": "Simulacrum",
-    "ritual": false,
     "level": 7,
-    "school": "Illusion"
+    "school": "Illusion",
+    "castingTime": "12 hours",
+    "ritual": false
   },
   "sleep": {
     "name": "Sleep",
-    "ritual": false,
     "level": 1,
-    "school": "Enchantment"
+    "school": "Enchantment",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "sleet-storm": {
     "name": "Sleet Storm",
-    "ritual": false,
     "level": 3,
-    "school": "Conjuration"
+    "school": "Conjuration",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "slow": {
     "name": "Slow",
-    "ritual": false,
     "level": 3,
-    "school": "Transmutation"
+    "school": "Transmutation",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "spare-the-dying": {
     "name": "Spare the Dying",
-    "ritual": false,
     "level": 0,
-    "school": "Necromancy"
+    "school": "Necromancy",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "speak-with-animals": {
     "name": "Speak with Animals",
-    "ritual": true,
     "level": 1,
-    "school": "Divination"
+    "school": "Divination",
+    "castingTime": "1 action",
+    "ritual": true
   },
   "speak-with-dead": {
     "name": "Speak with Dead",
-    "ritual": false,
     "level": 3,
-    "school": "Necromancy"
+    "school": "Necromancy",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "speak-with-plants": {
     "name": "Speak with Plants",
-    "ritual": false,
     "level": 3,
-    "school": "Transmutation"
+    "school": "Transmutation",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "spider-climb": {
     "name": "Spider Climb",
-    "ritual": false,
     "level": 2,
-    "school": "Transmutation"
+    "school": "Transmutation",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "spike-growth": {
     "name": "Spike Growth",
-    "ritual": false,
     "level": 2,
-    "school": "Transmutation"
+    "school": "Transmutation",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "spirit-guardians": {
     "name": "Spirit Guardians",
-    "ritual": false,
     "level": 3,
-    "school": "Conjuration"
+    "school": "Conjuration",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "spiritual-weapon": {
     "name": "Spiritual Weapon",
-    "ritual": false,
     "level": 2,
-    "school": "Evocation"
+    "school": "Evocation",
+    "castingTime": "1 bonus action",
+    "ritual": false
   },
   "stinking-cloud": {
     "name": "Stinking Cloud",
-    "ritual": false,
     "level": 3,
-    "school": "Conjuration"
+    "school": "Conjuration",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "stone-shape": {
     "name": "Stone Shape",
-    "ritual": false,
     "level": 4,
-    "school": "Transmutation"
+    "school": "Transmutation",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "stoneskin": {
     "name": "Stoneskin",
-    "ritual": false,
     "level": 4,
-    "school": "Abjuration"
+    "school": "Abjuration",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "storm-of-vengeance": {
     "name": "Storm of Vengeance",
-    "ritual": false,
     "level": 9,
-    "school": "Conjuration"
+    "school": "Conjuration",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "suggestion": {
     "name": "Suggestion",
-    "ritual": false,
     "level": 2,
-    "school": "Enchantment"
+    "school": "Enchantment",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "sunbeam": {
     "name": "Sunbeam",
-    "ritual": false,
     "level": 6,
-    "school": "Evocation"
+    "school": "Evocation",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "sunburst": {
     "name": "Sunburst",
-    "ritual": false,
     "level": 8,
-    "school": "Evocation"
+    "school": "Evocation",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "symbol": {
     "name": "Symbol",
-    "ritual": false,
     "level": 7,
-    "school": "Abjuration"
+    "school": "Abjuration",
+    "castingTime": "1 minute",
+    "ritual": false
   },
   "telekinesis": {
     "name": "Telekinesis",
-    "ritual": false,
     "level": 5,
-    "school": "Transmutation"
+    "school": "Transmutation",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "telepathic-bond": {
     "name": "Telepathic Bond",
-    "ritual": true,
     "level": 5,
-    "school": "Divination"
+    "school": "Divination",
+    "castingTime": "1 action",
+    "ritual": true
   },
   "teleport": {
     "name": "Teleport",
-    "ritual": false,
     "level": 7,
-    "school": "Conjuration"
+    "school": "Conjuration",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "teleportation-circle": {
     "name": "Teleportation Circle",
-    "ritual": false,
     "level": 5,
-    "school": "Conjuration"
+    "school": "Conjuration",
+    "castingTime": "1 minute",
+    "ritual": false
   },
   "thaumaturgy": {
     "name": "Thaumaturgy",
-    "ritual": false,
     "level": 0,
-    "school": "Transmutation"
+    "school": "Transmutation",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "thunderwave": {
     "name": "Thunderwave",
-    "ritual": false,
     "level": 1,
-    "school": "Evocation"
+    "school": "Evocation",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "time-stop": {
     "name": "Time Stop",
-    "ritual": false,
     "level": 9,
-    "school": "Transmutation"
+    "school": "Transmutation",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "tiny-hut": {
     "name": "Tiny Hut",
-    "ritual": true,
     "level": 3,
-    "school": "Evocation"
+    "school": "Evocation",
+    "castingTime": "1 minute",
+    "ritual": true
   },
   "tongues": {
     "name": "Tongues",
-    "ritual": false,
     "level": 3,
-    "school": "Divination"
+    "school": "Divination",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "transport-via-plants": {
     "name": "Transport via Plants",
-    "ritual": false,
     "level": 6,
-    "school": "Conjuration"
+    "school": "Conjuration",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "tree-stride": {
     "name": "Tree Stride",
-    "ritual": false,
     "level": 5,
-    "school": "Conjuration"
+    "school": "Conjuration",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "true-polymorph": {
     "name": "True Polymorph",
-    "ritual": false,
     "level": 9,
-    "school": "Transmutation"
+    "school": "Transmutation",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "true-resurrection": {
     "name": "True Resurrection",
-    "ritual": false,
     "level": 9,
-    "school": "Necromancy"
+    "school": "Necromancy",
+    "castingTime": "1 hour",
+    "ritual": false
   },
   "true-seeing": {
     "name": "True Seeing",
-    "ritual": false,
     "level": 6,
-    "school": "Divination"
+    "school": "Divination",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "true-strike": {
     "name": "True Strike",
-    "ritual": false,
     "level": 0,
-    "school": "Divination"
+    "school": "Divination",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "unseen-servant": {
     "name": "Unseen Servant",
-    "ritual": true,
     "level": 1,
-    "school": "Conjuration"
+    "school": "Conjuration",
+    "castingTime": "1 action",
+    "ritual": true
   },
   "vampiric-touch": {
     "name": "Vampiric Touch",
-    "ritual": false,
     "level": 3,
-    "school": "Necromancy"
+    "school": "Necromancy",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "vicious-mockery": {
     "name": "Vicious Mockery",
-    "ritual": false,
     "level": 0,
-    "school": "Enchantment"
+    "school": "Enchantment",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "wall-of-fire": {
     "name": "Wall of Fire",
-    "ritual": false,
     "level": 4,
-    "school": "Evocation"
+    "school": "Evocation",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "wall-of-force": {
     "name": "Wall of Force",
-    "ritual": false,
     "level": 5,
-    "school": "Evocation"
+    "school": "Evocation",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "wall-of-ice": {
     "name": "Wall of Ice",
-    "ritual": false,
     "level": 6,
-    "school": "Evocation"
+    "school": "Evocation",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "wall-of-stone": {
     "name": "Wall of Stone",
-    "ritual": false,
     "level": 5,
-    "school": "Evocation"
+    "school": "Evocation",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "wall-of-thorns": {
     "name": "Wall of Thorns",
-    "ritual": false,
     "level": 6,
-    "school": "Conjuration"
+    "school": "Conjuration",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "warding-bond": {
     "name": "Warding Bond",
-    "ritual": false,
     "level": 2,
-    "school": "Abjuration"
+    "school": "Abjuration",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "water-breathing": {
     "name": "Water Breathing",
-    "ritual": true,
     "level": 3,
-    "school": "Transmutation"
+    "school": "Transmutation",
+    "castingTime": "1 action",
+    "ritual": true
   },
   "water-walk": {
     "name": "Water Walk",
-    "ritual": true,
     "level": 3,
-    "school": "Transmutation"
+    "school": "Transmutation",
+    "castingTime": "1 action",
+    "ritual": true
   },
   "web": {
     "name": "Web",
-    "ritual": false,
     "level": 2,
-    "school": "Conjuration"
+    "school": "Conjuration",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "weird": {
     "name": "Weird",
-    "ritual": false,
     "level": 9,
-    "school": "Illusion"
+    "school": "Illusion",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "wind-walk": {
     "name": "Wind Walk",
-    "ritual": false,
     "level": 6,
-    "school": "Transmutation"
+    "school": "Transmutation",
+    "castingTime": "1 minute",
+    "ritual": false
   },
   "wind-wall": {
     "name": "Wind Wall",
-    "ritual": false,
     "level": 3,
-    "school": "Evocation"
+    "school": "Evocation",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "wish": {
     "name": "Wish",
-    "ritual": false,
     "level": 9,
-    "school": "Conjuration"
+    "school": "Conjuration",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "word-of-recall": {
     "name": "Word of Recall",
-    "ritual": false,
     "level": 6,
-    "school": "Conjuration"
+    "school": "Conjuration",
+    "castingTime": "1 action",
+    "ritual": false
   },
   "zone-of-truth": {
     "name": "Zone of Truth",
-    "ritual": false,
     "level": 2,
-    "school": "Enchantment"
+    "school": "Enchantment",
+    "castingTime": "1 action",
+    "ritual": false
   }
 }

--- a/spells/test-spells.py
+++ b/spells/test-spells.py
@@ -1,5 +1,18 @@
 import json
 
+SPELL_NAME_MIN_LENGTH = 3
+SPELL_LEVEL_VALUES = range(10)
+SPELL_SCHOOL_VALUES = [
+    'Abjuration',
+    'Conjuration',
+    'Divination',
+    'Enchantment',
+    'Evocation',
+    'Illusion',
+    'Necromancy',
+    'Transmutation'
+]
+
 
 def testSpell(spell: dict) -> bool:
     output = True
@@ -11,6 +24,9 @@ def testSpell(spell: dict) -> bool:
     elif not isinstance(name, str):
         output = False
         print(f"Failure: name not string in {spell}")
+    elif len(name) < SPELL_NAME_MIN_LENGTH:
+        output = False
+        print(f"Failure: name too short in {spell}")
     else:
         pass
 
@@ -21,6 +37,32 @@ def testSpell(spell: dict) -> bool:
     elif not isinstance(ritual, bool):
         output = False
         print(f"Failure: ritual not bool in {spell}")
+    else:
+        pass
+
+    level = spell.get("level")
+    if level == None:
+        output = False
+        print(f"Failure: no level found in {spell}")
+    elif not isinstance(level, int):
+        output = False
+        print(f"Failure: level not int in {spell}")
+    elif not level in SPELL_LEVEL_VALUES:
+        output = False
+        print(f"Failure: level not valid in {spell}")
+    else:
+        pass
+
+    school = spell.get("school")
+    if school == None:
+        output = False
+        print(f"Failure: no school found in {spell}")
+    elif not isinstance(school, str):
+        output = False
+        print(f"Failure: school not str in {spell}")
+    elif not school in SPELL_SCHOOL_VALUES:
+        output = False
+        print(f"Failure: school not valid in {spell}")
     else:
         pass
 

--- a/spells/test-spells.py
+++ b/spells/test-spells.py
@@ -133,7 +133,7 @@ def testSpellRitual(spell: dict) -> bool:
         return True
 
 
-def testSpellCastingRange(spell: dict) -> bool:
+def testSpellRange(spell: dict) -> bool:
     spellRange = spell.get("range")
     if spellRange == None:
         print(f"Failure: no range found in {spell}")
@@ -152,16 +152,11 @@ def testSpell(spell: dict) -> bool:
     output = True
 
     output = output and testSpellName(spell)
-
     output = output and testSpellLevel(spell)
-
     output = output and testSpellSchool(spell)
-
     output = output and testSpellCastingTime(spell)
-
     output = output and testSpellRitual(spell)
-
-    output = output and testSpellCastingRange(spell)
+    output = output and testSpellRange(spell)
 
     return output
 

--- a/spells/test-spells.py
+++ b/spells/test-spells.py
@@ -13,10 +13,9 @@ SPELL_SCHOOL_VALUES = [
     'Necromancy',
     'Transmutation'
 ]
-SPELL_CASTING_TIME_REGEX_STRINGS = [
+SPELL_CASTING_TIME_VALUES = [
     '1 action',
     '1 bonus action',
-    # '1 reaction',
     '1 minute',
     '10 minutes',
     '1 hour',
@@ -25,9 +24,7 @@ SPELL_CASTING_TIME_REGEX_STRINGS = [
     '24 hours',
     '1 action or 8 hours'
 ]
-SPELL_CASTING_TIME_REGEXES = []
-for string in SPELL_CASTING_TIME_REGEX_STRINGS:
-    SPELL_CASTING_TIME_REGEXES.append(re.compile(string))
+REACTION_REGEX = re.compile('1 reaction, ')
 
 
 def testSpellName(spell: dict) -> bool:
@@ -83,12 +80,11 @@ def testSpellCastingTime(spell: dict) -> bool:
     elif not isinstance(castingTime, str):
         print(f"Failure: castingTime not str in {spell}")
         return False
-    else:
-        for pattern in SPELL_CASTING_TIME_REGEXES:
-            if pattern.match(castingTime):
-                return True
+    elif (not castingTime in SPELL_CASTING_TIME_VALUES) and not REACTION_REGEX.match(castingTime):
         print(f"Failure: castingTime not valid in {spell}")
         return False
+    else:
+        return True
 
 
 def testSpellRitual(spell: dict) -> bool:

--- a/spells/test-spells.py
+++ b/spells/test-spells.py
@@ -1,0 +1,50 @@
+import json
+
+
+def testSpell(spell: dict) -> bool:
+    output = True
+
+    name = spell.get("name")
+    if name == None:
+        output = False
+        print(f"Failure: no name found in {spell}")
+    elif not isinstance(name, str):
+        output = False
+        print(f"Failure: name not string in {spell}")
+    else:
+        pass
+
+    ritual = spell.get("ritual")
+    if ritual == None:
+        output = False
+        print(f"Failure: no ritual found in {spell}")
+    elif not isinstance(ritual, bool):
+        output = False
+        print(f"Failure: ritual not bool in {spell}")
+    else:
+        pass
+
+    return output
+
+
+def main():
+    spells_path = "spells.json"
+    with open(spells_path) as fp:
+        spells = json.load(fp)
+
+    all_passed = True
+    failed_count = 0
+    for key in spells:
+        if not testSpell(spells[key]):
+            all_passed = False
+            failed_count = failed_count + 1
+            print(f"Failed for key: {key}")
+
+    if all_passed:
+        print("Testing complete: all spells passed!")
+    else:
+        print(f"Testing complete: {failed_count} spell(s) failed.")
+
+
+if __name__ == "__main__":
+    main()

--- a/spells/test-spells.py
+++ b/spells/test-spells.py
@@ -22,9 +22,43 @@ SPELL_CASTING_TIME_VALUES = [
     '8 hours',
     '12 hours',
     '24 hours',
-    '1 action or 8 hours'
+    '1 action or 8 hours',
+    '1 reaction, which you take when you see a creature within 60 feet of you casting a spell',
+    '1 reaction, which you take when you or a creature within 60 feet of you falls',
+    '1 reaction, which you take in response to being damaged by a creature within 60 feet of you that you can see',
+    '1 reaction, which you take when you are hit by an attack or targeted by the magic missile spell',
 ]
-REACTION_REGEX = re.compile('1 reaction, ')
+SPELL_RANGE_VALUES = [
+    'Self',
+    'Touch',
+    'Sight',
+    'Unlimited',
+    'Special',
+    '5 feet',
+    '10 feet',
+    '30 feet',
+    '60 feet',
+    '90 feet',
+    '100 feet',
+    '120 feet',
+    '150 feet',
+    '300 feet',
+    '500 feet',
+    '1 mile',
+    '500 miles',
+    'Self (10-foot radius)',
+    'Self (15-foot radius)',
+    'Self (30-foot radius)',
+    'Self (5-mile radius)',
+    'Self (10-foot-radius sphere)',
+    'Self (10-foot-radius hemisphere)',
+    'Self (15-foot cone)',
+    'Self (30-foot cone)',
+    'Self (60-foot cone)',
+    'Self (60-foot line)',
+    'Self (100-foot line)',
+    'Self (15-foot cube)',
+]
 
 
 def testSpellName(spell: dict) -> bool:
@@ -80,7 +114,7 @@ def testSpellCastingTime(spell: dict) -> bool:
     elif not isinstance(castingTime, str):
         print(f"Failure: castingTime not str in {spell}")
         return False
-    elif (not castingTime in SPELL_CASTING_TIME_VALUES) and not REACTION_REGEX.match(castingTime):
+    elif (not castingTime in SPELL_CASTING_TIME_VALUES):
         print(f"Failure: castingTime not valid in {spell}")
         return False
     else:
@@ -99,6 +133,21 @@ def testSpellRitual(spell: dict) -> bool:
         return True
 
 
+def testSpellCastingRange(spell: dict) -> bool:
+    spellRange = spell.get("range")
+    if spellRange == None:
+        print(f"Failure: no range found in {spell}")
+        return False
+    elif not isinstance(spellRange, str):
+        print(f"Failure: range not str in {spell}")
+        return False
+    elif (not spellRange in SPELL_RANGE_VALUES):
+        print(f"Failure: range not valid in {spell}")
+        return False
+    else:
+        return True
+
+
 def testSpell(spell: dict) -> bool:
     output = True
 
@@ -111,6 +160,8 @@ def testSpell(spell: dict) -> bool:
     output = output and testSpellCastingTime(spell)
 
     output = output and testSpellRitual(spell)
+
+    output = output and testSpellCastingRange(spell)
 
     return output
 

--- a/spells/test-spells.py
+++ b/spells/test-spells.py
@@ -1,4 +1,5 @@
 import json
+import re
 
 SPELL_NAME_MIN_LENGTH = 3
 SPELL_LEVEL_VALUES = range(10)
@@ -12,59 +13,108 @@ SPELL_SCHOOL_VALUES = [
     'Necromancy',
     'Transmutation'
 ]
+SPELL_CASTING_TIME_REGEX_STRINGS = [
+    '1 action',
+    '1 bonus action',
+    # '1 reaction',
+    '1 minute',
+    '10 minutes',
+    '1 hour',
+    '8 hours',
+    '12 hours',
+    '24 hours',
+    '1 action or 8 hours'
+]
+SPELL_CASTING_TIME_REGEXES = []
+for string in SPELL_CASTING_TIME_REGEX_STRINGS:
+    SPELL_CASTING_TIME_REGEXES.append(re.compile(string))
+
+
+def testSpellName(spell: dict) -> bool:
+    name = spell.get("name")
+    if name == None:
+        print(f"Failure: no name found in {spell}")
+        return False
+    elif not isinstance(name, str):
+        print(f"Failure: name not string in {spell}")
+        return False
+    elif len(name) < SPELL_NAME_MIN_LENGTH:
+        print(f"Failure: name too short in {spell}")
+        return False
+    else:
+        return True
+
+
+def testSpellLevel(spell: dict) -> bool:
+    level = spell.get("level")
+    if level == None:
+        print(f"Failure: no level found in {spell}")
+        return False
+    elif not isinstance(level, int):
+        print(f"Failure: level not int in {spell}")
+        return False
+    elif not level in SPELL_LEVEL_VALUES:
+        print(f"Failure: level not valid in {spell}")
+        return False
+    else:
+        return True
+
+
+def testSpellSchool(spell: dict) -> bool:
+    school = spell.get("school")
+    if school == None:
+        print(f"Failure: no school found in {spell}")
+        return False
+    elif not isinstance(school, str):
+        print(f"Failure: school not str in {spell}")
+        return False
+    elif not school in SPELL_SCHOOL_VALUES:
+        print(f"Failure: school not valid in {spell}")
+        return False
+    else:
+        return True
+
+
+def testSpellCastingTime(spell: dict) -> bool:
+    castingTime = spell.get("castingTime")
+    if castingTime == None:
+        print(f"Failure: no castingTime found in {spell}")
+        return False
+    elif not isinstance(castingTime, str):
+        print(f"Failure: castingTime not str in {spell}")
+        return False
+    else:
+        for pattern in SPELL_CASTING_TIME_REGEXES:
+            if pattern.match(castingTime):
+                return True
+        print(f"Failure: castingTime not valid in {spell}")
+        return False
+
+
+def testSpellRitual(spell: dict) -> bool:
+    ritual = spell.get("ritual")
+    if ritual == None:
+        print(f"Failure: no ritual found in {spell}")
+        return False
+    elif not isinstance(ritual, bool):
+        print(f"Failure: ritual not bool in {spell}")
+        return False
+    else:
+        return True
 
 
 def testSpell(spell: dict) -> bool:
     output = True
 
-    name = spell.get("name")
-    if name == None:
-        output = False
-        print(f"Failure: no name found in {spell}")
-    elif not isinstance(name, str):
-        output = False
-        print(f"Failure: name not string in {spell}")
-    elif len(name) < SPELL_NAME_MIN_LENGTH:
-        output = False
-        print(f"Failure: name too short in {spell}")
-    else:
-        pass
+    output = output and testSpellName(spell)
 
-    ritual = spell.get("ritual")
-    if ritual == None:
-        output = False
-        print(f"Failure: no ritual found in {spell}")
-    elif not isinstance(ritual, bool):
-        output = False
-        print(f"Failure: ritual not bool in {spell}")
-    else:
-        pass
+    output = output and testSpellLevel(spell)
 
-    level = spell.get("level")
-    if level == None:
-        output = False
-        print(f"Failure: no level found in {spell}")
-    elif not isinstance(level, int):
-        output = False
-        print(f"Failure: level not int in {spell}")
-    elif not level in SPELL_LEVEL_VALUES:
-        output = False
-        print(f"Failure: level not valid in {spell}")
-    else:
-        pass
+    output = output and testSpellSchool(spell)
 
-    school = spell.get("school")
-    if school == None:
-        output = False
-        print(f"Failure: no school found in {spell}")
-    elif not isinstance(school, str):
-        output = False
-        print(f"Failure: school not str in {spell}")
-    elif not school in SPELL_SCHOOL_VALUES:
-        output = False
-        print(f"Failure: school not valid in {spell}")
-    else:
-        pass
+    output = output and testSpellCastingTime(spell)
+
+    output = output and testSpellRitual(spell)
 
     return output
 


### PR DESCRIPTION
## What's in this PR?
This PR is a WIP checkpoint that does the following:
- Updated .gitignore to include some obvious stuff
- Added `process-spells-from-export.py` which processes the exported spells into a more consistent and usable format.
- Added `spells/spells.json` which contains the name, level, school, casting time, ritual boolean, and range for each SRD spell.
- Added `spells/test-spells.py` which verifies that all the spells in the JSON are valid.

This PR represents a significant amount of progress. Next step will be adding components, durations, and descriptions!

## 🐢
